### PR TITLE
Add background vendor export

### DIFF
--- a/app/Console/Commands/ExportVendorsCommand.php
+++ b/app/Console/Commands/ExportVendorsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class ExportVendorsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'vendor:export {exportId}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run a vendor export asynchronously';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $exportId = (int) $this->argument('exportId');
+
+        $export = \App\Models\VendorExport::find($exportId);
+        if (! $export) {
+            $this->error('Export record not found');
+            return Command::FAILURE;
+        }
+
+        try {
+            $fileName = 'vendors_' . now()->format('Y_m_d_H_i_s') . '.xlsx';
+            $filePath = 'uploads/report/vendor/' . $fileName;
+
+            $filters = [
+                'range_start' => $export->range_start,
+                'range_end'   => $export->range_end,
+            ];
+
+            \Maatwebsite\Excel\Facades\Excel::store(
+                new \App\Exports\VendorsExport($filters),
+                $filePath,
+                'public'
+            );
+
+            $export->update([
+                'status'    => 'completed',
+                'file_name' => $fileName,
+            ]);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $export->update(['status' => 'failed']);
+            $this->error($e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Http/Controllers/Admin/VendorExportController.php
+++ b/app/Http/Controllers/Admin/VendorExportController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\VendorExport;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\Request;
+
+class VendorExportController extends Controller
+{
+    public function index()
+    {
+        $exports = VendorExport::latest()->paginate(20);
+        return view('admin.vendor_exports.index', compact('exports'));
+    }
+
+    public function create()
+    {
+        return view('admin.vendor_exports.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'range_start' => 'required|integer|min:0',
+            'range_end'   => 'required|integer|gt:range_start',
+        ]);
+
+        $export = VendorExport::create([
+            'range_start' => $request->range_start,
+            'range_end'   => $request->range_end,
+            'status'      => 'in_progress',
+        ]);
+
+        // Run the export command in the background
+        $cmd = sprintf('php artisan vendor:export %d > /dev/null 2>&1 &', $export->id);
+        exec($cmd);
+
+        return redirect()->route('admin.vendor-exports.index')
+            ->with('success', 'Export started.');
+    }
+
+    public function download($id)
+    {
+        $export = VendorExport::findOrFail($id);
+        $filePath = public_path('uploads/report/vendor/' . $export->file_name);
+
+        if (! file_exists($filePath)) {
+            abort(404);
+        }
+
+        return response()->download($filePath);
+    }
+
+    public function destroy($id)
+    {
+        $export = VendorExport::findOrFail($id);
+
+        if ($export->file_name) {
+            $path = public_path('uploads/report/vendor/' . $export->file_name);
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        $export->delete();
+
+        return redirect()->route('admin.vendor-exports.index')
+            ->with('success', 'Export deleted.');
+    }
+}

--- a/app/Models/VendorExport.php
+++ b/app/Models/VendorExport.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class VendorExport extends Model
+{
+    protected $fillable = [
+        'range_start',
+        'range_end',
+        'status',
+        'file_name',
+    ];
+}

--- a/database/migrations/2025_06_17_112848_create_vendor_exports_table.php
+++ b/database/migrations/2025_06_17_112848_create_vendor_exports_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vendor_exports', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('range_start');
+            $table->unsignedBigInteger('range_end');
+            $table->string('status')->default('in_progress');
+            $table->string('file_name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vendor_exports');
+    }
+};

--- a/resources/views/admin/vendor_exports/create.blade.php
+++ b/resources/views/admin/vendor_exports/create.blade.php
@@ -1,0 +1,28 @@
+@extends('admin.layouts.app')
+@section('title', 'Vendor Export | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title">New Vendor Export</h4>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ route('admin.vendor-exports.store') }}">
+                    @csrf
+                    <div class="mb-3">
+                        <label class="form-label">Range Start</label>
+                        <input type="number" name="range_start" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Range End</label>
+                        <input type="number" name="range_end" class="form-control" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Start Export</button>
+                    <a href="{{ route('admin.vendor-exports.index') }}" class="btn btn-secondary">Back</a>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/vendor_exports/index.blade.php
+++ b/resources/views/admin/vendor_exports/index.blade.php
@@ -1,0 +1,53 @@
+@extends('admin.layouts.app')
+@section('title', 'Vendor Exports | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h4 class="card-title">Vendor Exports</h4>
+                <a href="{{ route('admin.vendor-exports.create') }}" class="btn btn-primary">New Export</a>
+            </div>
+            <div class="card-body">
+                @if(session('success'))
+                    <div class="alert alert-success">{{ session('success') }}</div>
+                @endif
+                <div class="table-responsive">
+                    <table class="table table-bordered">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Range</th>
+                                <th>Status</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($exports as $export)
+                                <tr>
+                                    <td>{{ $export->id }}</td>
+                                    <td>{{ number_format($export->range_start) }} - {{ number_format($export->range_end) }}</td>
+                                    <td>{{ ucfirst($export->status) }}</td>
+                                    <td>
+                                        @if($export->status === 'completed')
+                                            <a href="{{ route('admin.vendor-exports.download', $export->id) }}" class="btn btn-sm btn-success">Download</a>
+                                        @else
+                                            <span class="text-muted">Processing</span>
+                                        @endif
+                                        <form action="{{ route('admin.vendor-exports.destroy', $export->id) }}" method="POST" class="d-inline">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete export?')">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                {{ $exports->links() }}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/vendors/index.blade.php
+++ b/resources/views/admin/vendors/index.blade.php
@@ -63,9 +63,9 @@
                                     <i class="bi bi-arrow-clockwise"></i> RESET
                                 </button>
 
-                                <button type="button" id="export-vendors" class="btn btn-success">
-                                    <i class="bi bi-file-earmark-excel"></i> Export
-                                </button>
+                                <a href="{{ route('admin.vendor-exports.index') }}" class="btn btn-success">
+                                    <i class="bi bi-file-earmark-excel"></i> Exports
+                                </a>
                             </div>
                         </form>
                     </div>
@@ -117,31 +117,7 @@
             </div>
         </div>
     </div>
-    <!-- Export Range Modal -->
-    <!-- Export Range Modal -->
-    <div class="modal fade" id="exportRangeModal" tabindex="-1" aria-labelledby="exportRangeModalLabel"
-        aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Select Export Range</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <select class="form-select" id="exportRange">
-                        <option value="0-50000">0 - 50,000</option>
-                        <option value="50000-100000">50,000 - 100,000</option>
-                        <option value="100000-150000">100,000 - 150,000</option>
-                    </select>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" id="startExportBtn" class="btn btn-primary">Start Export</button>
-                </div>
-            </div>
-        </div>
-    </div>
 
-    <!-- Progress Container removed -->
 
 
 
@@ -280,30 +256,7 @@
                 });
             });
 
-            // --- Export Functionality ---
-            $('#export-vendors').click(function() {
-                $('#exportRangeModal').modal('show');
-            });
 
-            $('#startExportBtn').click(function() {
-                const selectedRange = $('#exportRange').val();
-                const [range_start, range_end] = selectedRange.split('-');
-                const params = {
-                    name: $('#name').val(),
-                    email: $('#email').val(),
-                    status: $('#status').val(),
-                    gst_no: $('#gst_no').val(),
-                    phone: $('#phone').val(),
-                    range_start,
-                    range_end
-                };
-
-                const query = $.param(params);
-                $('#exportRangeModal').modal('hide');
-                window.location.href = "{{ route('admin.vendors.export') }}?" + query;
-            });
-
-            // Progress related functions removed for simplified export
 
         });
     </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\VendorController;
+use App\Http\Controllers\Admin\VendorExportController;
 use App\Http\Controllers\Admin\BuyerController;
 use App\Http\Controllers\Admin\PendingProductController;
 use App\Http\Controllers\Admin\ApprovedProductController;
@@ -63,10 +64,17 @@ Route::middleware(['auth'])->group(function () {
         Route::put('update/{id}', [VendorController::class, 'update'])->name('update');
         Route::post('update-profile-verification', [VendorController::class, 'updateProfileVerification'])->name('update-profile-verification');
         Route::get('{id}', [VendorController::class, 'show'])->name('show');
-        Route::get('export', [VendorController::class, 'exportVendors'])->name('export');
         Route::get('search', [VendorController::class, 'search'])->name('search');
         Route::get('fetch', [VendorController::class, 'fetchVendors'])->name('fetch');
         Route::get('render-table', [VendorController::class, 'renderVendorsTable'])->name('render-table');
+    });
+
+    Route::prefix('admin/vendor-exports')->name('admin.vendor-exports.')->group(function () {
+        Route::get('/', [VendorExportController::class, 'index'])->name('index');
+        Route::get('create', [VendorExportController::class, 'create'])->name('create');
+        Route::post('store', [VendorExportController::class, 'store'])->name('store');
+        Route::get('{id}/download', [VendorExportController::class, 'download'])->name('download');
+        Route::delete('{id}', [VendorExportController::class, 'destroy'])->name('destroy');
     });
 
     Route::prefix('admin/buyers')->name('admin.buyers.')->group(function () {


### PR DESCRIPTION
## Summary
- add `vendor_exports` table for asynchronous exports
- create `VendorExport` model and controller
- implement `ExportVendorsCommand` CLI command
- add export management views and routes
- update vendor listing to link to export page

## Testing
- `composer install`
- `APP_KEY=base64:ZUuuugMC0Odmw4A9JQFPgT1IFs4lM4f1aIehiWFNEqE= php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_685150c34aac83279d7d21f02a95bec3