### PR TITLE
Adjust buyer profile schema and list actions

### DIFF
--- a/app/Http/Controllers/Admin/BuyerController.php
+++ b/app/Http/Controllers/Admin/BuyerController.php
@@ -51,9 +51,6 @@ class BuyerController extends Controller
                     <a href="'.route('admin.buyers.edit', $buyer->id).'" class="btn btn-sm btn-soft-primary">
                         <i class="bi bi-pencil"></i> Edit
                     </a>
-                    <button class="btn btn-sm btn-soft-danger delete-buyer" data-id="'.$buyer->id.'">
-                        <i class="bi bi-trash"></i> Delete
-                    </button>
                 ';
             })
             ->rawColumns(['status', 'action'])

--- a/app/Models/BuyerProfile.php
+++ b/app/Models/BuyerProfile.php
@@ -12,7 +12,7 @@ class BuyerProfile extends Model
 
     protected $fillable = [
         'user_id',
-        'name',
+        'store_name',
         'email',
         'phone',
         'country',
@@ -20,6 +20,9 @@ class BuyerProfile extends Model
         'city',
         'pincode',
         'address',
+        'gst_no',
+        'gst_doc',
+        'store_logo',
     ];
 
     /**

--- a/database/migrations/2025_06_08_043656_create_buyer_profiles_table.php
+++ b/database/migrations/2025_06_08_043656_create_buyer_profiles_table.php
@@ -13,8 +13,9 @@ return new class extends Migration
     {
         Schema::create('buyer_profiles', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('user_id');
-            $table->string('name', 255)->nullable();
+            $table->unsignedBigInteger('user_id'); // Foreign key to users table
+
+            $table->string('store_name', 22)->nullable();
             $table->string('email', 255)->nullable();
             $table->string('phone', 20)->nullable();
             $table->string('country')->nullable();
@@ -22,6 +23,10 @@ return new class extends Migration
             $table->string('city')->nullable();
             $table->string('pincode', 20)->nullable();
             $table->text('address')->nullable();
+            $table->string('gst_no', 20)->nullable();
+            $table->text('gst_doc')->nullable();
+            $table->text('store_logo')->nullable();
+
             $table->timestamps();
         });
     }

--- a/resources/views/admin/buyers/_buyers_table.blade.php
+++ b/resources/views/admin/buyers/_buyers_table.blade.php
@@ -37,9 +37,6 @@
                     <a href="{{ route('admin.buyers.edit', $buyer->id) }}" class="btn btn-sm btn-soft-primary" title="Edit">
                         <i class="bi bi-pencil"></i>
                     </a>
-                    <button class="btn btn-sm btn-soft-danger delete-buyer" data-id="{{ $buyer->id }}">
-                        <i class="bi bi-trash"></i>
-                    </button>
                 </div>
             </td>
         </tr>

--- a/resources/views/admin/buyers/index.blade.php
+++ b/resources/views/admin/buyers/index.blade.php
@@ -168,23 +168,6 @@
                 fetchBuyersData(1, $(this).val());
             });
 
-            // Delete buyer event
-            $(document).on('click', '.delete-buyer', function() {
-                if (!confirm('Are you sure you want to delete this buyer?')) {
-                    return;
-                }
-                const id = $(this).data('id');
-                $.ajax({
-                    url: "{{ url('admin/buyers/delete') }}/" + id,
-                    method: 'DELETE',
-                    data: {
-                        _token: '{{ csrf_token() }}'
-                    },
-                    success: function() {
-                        fetchBuyersData(1);
-                    }
-                });
-            });
         });
     </script>
 @endsection


### PR DESCRIPTION
## Summary
- update `buyer_profiles` table migration to match vendor fields
- align BuyerProfile model fillable attributes
- drop delete button from buyer list and JS
- remove delete option in BuyerController action column

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a2ab6ca48327b7527952cd3064f5