### PR TITLE
Add buyer profile verification toggle

### DIFF
--- a/app/Http/Controllers/Admin/BuyerController.php
+++ b/app/Http/Controllers/Admin/BuyerController.php
@@ -351,4 +351,29 @@ class BuyerController extends Controller
             ], 500);
         }
     }
+
+    /**
+     * Update profile verification status for a buyer.
+     */
+    public function updateProfileVerification(Request $request)
+    {
+        try {
+            $buyer = User::where('id', $request->id)
+                ->where('role', 'buyer')
+                ->firstOrFail();
+
+            $buyer->is_profile_verified = $request->is_profile_verified;
+            $buyer->save();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Profile verification status updated successfully',
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Error updating profile verification status: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
 }

--- a/resources/views/admin/buyers/_buyers_table.blade.php
+++ b/resources/views/admin/buyers/_buyers_table.blade.php
@@ -28,6 +28,11 @@
                 @endphp
                 <span class="{{ $statusClass }}">{{ ucfirst($status) }}</span>
             </td>
+            <td>
+                <div class="form-check form-switch">
+                    <input type="checkbox" class="form-check-input profile-verified-toggle" data-id="{{ $buyer->id }}" {{ $buyer->is_profile_verified == 1 ? 'checked' : '' }}>
+                </div>
+            </td>
             <td>{{ \Carbon\Carbon::parse($buyer->created_at)->format('d M Y') }}</td>
             <td>
                 <div class="d-flex gap-2">
@@ -42,7 +47,7 @@
         </tr>
     @empty
         <tr>
-            <td colspan="8" class="text-center">No buyers found.</td>
+            <td colspan="9" class="text-center">No buyers found.</td>
         </tr>
     @endforelse
 </tbody>

--- a/resources/views/admin/buyers/index.blade.php
+++ b/resources/views/admin/buyers/index.blade.php
@@ -76,6 +76,7 @@
                                     <th>Phone</th>
                                     <th>Store Info</th>
                                     <th>Status</th>
+                                    <th>Verified</th>
                                     <th>Created At</th>
                                     <th>Action</th>
                                 </tr>
@@ -83,12 +84,12 @@
                             {{-- Table body and pagination will be loaded via AJAX --}}
                             <tbody id="buyers-table-body-content">
                                 <tr>
-                                    <td colspan="8" class="text-center">Loading Buyers...</td>
+                                    <td colspan="9" class="text-center">Loading Buyers...</td>
                                 </tr>
                             </tbody>
                             <tfoot id="buyers-table-foot-content">
                                 <tr>
-                                    <td colspan="8" class="text-center"></td>
+                                    <td colspan="9" class="text-center"></td>
                                 </tr>
                             </tfoot>
                         </table>
@@ -166,6 +167,36 @@
 
             $(document).on('change', '#perPage', function() {
                 fetchBuyersData(1, $(this).val());
+            });
+
+            // Handle profile verification toggle change
+            $(document).on('change', '.profile-verified-toggle', function() {
+                var $toggle = $(this);
+                var userId = $toggle.data('id');
+                var isVerified = $toggle.is(':checked') ? 1 : 0;
+
+                $.ajax({
+                    url: "{{ route('admin.buyers.update-profile-verification') }}",
+                    method: 'POST',
+                    data: {
+                        id: userId,
+                        is_profile_verified: isVerified,
+                        _token: '{{ csrf_token() }}'
+                    },
+                    success: function(response) {
+                        if (response.success) {
+                            toastr.success(response.message);
+                        } else {
+                            toastr.error(response.message);
+                            $toggle.prop('checked', !$toggle.is(':checked'));
+                        }
+                    },
+                    error: function(xhr) {
+                        toastr.error('An error occurred. Please try again.');
+                        console.error('AJAX error:', xhr.responseText);
+                        $toggle.prop('checked', !$toggle.is(':checked'));
+                    }
+                });
             });
 
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,6 +86,7 @@ Route::middleware(['auth'])->group(function () {
         Route::post('store', [BuyerController::class, 'store'])->name('store');
         Route::get('edit/{id}', [BuyerController::class, 'edit'])->name('edit');
         Route::put('update/{id}', [BuyerController::class, 'update'])->name('update');
+        Route::post('update-profile-verification', [BuyerController::class, 'updateProfileVerification'])->name('update-profile-verification');
         Route::get('{id}', [BuyerController::class, 'show'])->name('show');
         Route::delete('delete/{id}', [BuyerController::class, 'destroy'])->name('delete');
     });


### PR DESCRIPTION
## Summary
- implement profile verification toggle for buyers
- update buyers table UI to include Verified column and toggle
- handle verification updates via new route and controller method
- adjust JS to send AJAX request on toggle
- install PHP and dependencies for tests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6851ab1793448327bf26990534a1adc9