### PR TITLE
AJAX-driven user management

### DIFF
--- a/resources/views/admin/users/_users_table.blade.php
+++ b/resources/views/admin/users/_users_table.blade.php
@@ -1,0 +1,32 @@
+{{-- This partial renders users table body and pagination --}}
+<tbody>
+    @forelse($users as $index => $user)
+        <tr>
+            <td>{{ ($users->currentPage() - 1) * $users->perPage() + $loop->iteration }}</td>
+            <td>{{ htmlspecialchars($user->name) }}</td>
+            <td>{{ htmlspecialchars($user->email) }}</td>
+            <td>{{ ucfirst($user->role) }}</td>
+            <td>
+                @php
+                    $status = $user->status ? 'active' : 'inactive';
+                    $statusClass = $user->status ? 'badge border border-success text-success px-2 py-1 fs-13' : 'badge border border-danger text-danger px-2 py-1 fs-13';
+                @endphp
+                <span class="{{ $statusClass }}">{{ ucfirst($status) }}</span>
+            </td>
+            <td>
+                <a href="{{ route('admin.users.edit', $user->id) }}" class="btn btn-sm btn-soft-primary" title="Edit">
+                    <iconify-icon icon="solar:pen-2-broken" class="fs-18"></iconify-icon>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="6" class="text-center">No users found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$users" />
+    </tr>
+</tfoot>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -8,7 +8,7 @@
                     <h4 class="card-title mb-0">Add User</h4>
                 </div>
                 <div class="card-body">
-                    <form action="{{ route('admin.users.store') }}" method="POST">
+                    <form action="{{ route('admin.users.store') }}" method="POST" id="userForm">
                         @csrf
                         <div class="mb-3">
                             <label class="form-label">Name</label>
@@ -48,4 +48,62 @@
             </div>
         </div>
     </div>
+    <script>
+        $(document).ready(function() {
+            function validateForm() {
+                let isValid = true;
+                $('#userForm .error-message').remove();
+                $('#userForm input[required]').each(function() {
+                    if (!$(this).val()) {
+                        isValid = false;
+                        $(this).addClass('is-invalid');
+                        $(this).after('<span class="text-danger error-message">This field is required</span>');
+                    } else {
+                        $(this).removeClass('is-invalid');
+                    }
+                });
+                return isValid;
+            }
+            $('#userForm').on('submit', function(e) {
+                e.preventDefault();
+                if (!validateForm()) {
+                    toastr.error('Please fix the validation errors.');
+                    return false;
+                }
+                var formData = $(this).serialize();
+                $.ajax({
+                    url: $(this).attr('action'),
+                    type: 'POST',
+                    data: formData,
+                    beforeSend: function() {
+                        $('button[type="submit"]').prop('disabled', true).html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Saving...');
+                    },
+                    success: function(response) {
+                        if (response.status == 1) {
+                            toastr.success(response.message);
+                            setTimeout(function() {
+                                window.location.href = response.redirect || "{{ route('admin.users.index') }}";
+                            }, 1000);
+                        } else {
+                            toastr.error(response.message || 'An error occurred');
+                        }
+                    },
+                    error: function(xhr) {
+                        if (xhr.responseJSON && xhr.responseJSON.errors) {
+                            $.each(xhr.responseJSON.errors, function(key, value) {
+                                toastr.error(value[0]);
+                            });
+                        } else if (xhr.responseJSON && xhr.responseJSON.message) {
+                            toastr.error(xhr.responseJSON.message);
+                        } else {
+                            toastr.error('An error occurred. Please try again.');
+                        }
+                    },
+                    complete: function() {
+                        $('button[type="submit"]').prop('disabled', false).html('Save');
+                    }
+                });
+            });
+        });
+    </script>
 @endsection

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -10,41 +10,151 @@
                         <i class="bi bi-plus-lg"></i> Add User
                     </a>
                 </div>
-                <div class="table-responsive">
-                    <table class="table align-middle mb-0 table-striped table-centered">
-                        <thead class="bg-light-subtle">
-                            <tr>
-                                <th>#</th>
-                                <th>Name</th>
-                                <th>Email</th>
-                                <th>Role</th>
-                                <th>Status</th>
-                                <th>Action</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @forelse($users as $user)
+                <div>
+                    <div class="card-body">
+                        <form id="filter-form" class="row g-2 align-items-end">
+                            <div class="col-md-3">
+                                <label class="form-label">Name</label>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="bi bi-person"></i></span>
+                                    <input type="text" id="name" class="form-control" placeholder="User Name">
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">Email</label>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="bi bi-envelope"></i></span>
+                                    <input type="text" id="email" class="form-control" placeholder="User Email">
+                                </div>
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label">Role</label>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="bi bi-people"></i></span>
+                                    <select id="role" class="form-select">
+                                        <option value="">All</option>
+                                        <option value="vendor">Vendor</option>
+                                        <option value="buyer">Buyer</option>
+                                        <option value="admin">Admin</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label">Status</label>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="bi bi-check2-circle"></i></span>
+                                    <select id="status" class="form-select">
+                                        <option value="">All</option>
+                                        <option value="1">Active</option>
+                                        <option value="0">Inactive</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <button type="button" id="search" class="btn btn-primary">
+                                    <i class="bi bi-search"></i> SEARCH
+                                </button>
+                                <button type="button" id="reset" class="btn btn-outline-danger">
+                                    <i class="bi bi-arrow-clockwise"></i> RESET
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="table-responsive px-4 mb-3">
+                        <table class="table align-middle mb-0 table-striped table-centered" id="users-table" style="width:100%;">
+                            <thead class="bg-light-subtle">
                                 <tr>
-                                    <td>{{ $loop->iteration }}</td>
-                                    <td>{{ $user->name }}</td>
-                                    <td>{{ $user->email }}</td>
-                                    <td>{{ ucfirst($user->role) }}</td>
-                                    <td>{{ $user->status ? 'Active' : 'Inactive' }}</td>
-                                    <td>
-                                        <a href="{{ route('admin.users.edit', $user->id) }}" class="btn btn-sm btn-soft-primary">
-                                            <iconify-icon icon="solar:pen-2-broken" class="fs-18"></iconify-icon>
-                                        </a>
-                                    </td>
+                                    <th>#</th>
+                                    <th>Name</th>
+                                    <th>Email</th>
+                                    <th>Role</th>
+                                    <th>Status</th>
+                                    <th>Action</th>
                                 </tr>
-                            @empty
+                            </thead>
+                            <tbody id="users-table-body-content">
                                 <tr>
-                                    <td colspan="6" class="text-center">No users found.</td>
+                                    <td colspan="6" class="text-center">Loading Users...</td>
                                 </tr>
-                            @endforelse
-                        </tbody>
-                    </table>
+                            </tbody>
+                            <tfoot id="users-table-foot-content">
+                                <tr>
+                                    <td colspan="6" class="text-center"></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
+
+    <script>
+        $(document).ready(function() {
+            fetchUsersData(1);
+            var currentAjaxRequest = null;
+
+            function fetchUsersData(page = 1, perPage = null) {
+                if (currentAjaxRequest && currentAjaxRequest.readyState !== 4) {
+                    currentAjaxRequest.abort();
+                }
+                $('#users-table-body-content').html('<tr><td colspan="6" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+                $('#users-table-foot-content').empty();
+
+                const filters = {
+                    name: $('#name').val(),
+                    email: $('#email').val(),
+                    role: $('#role').val(),
+                    status: $('#status').val()
+                };
+                perPage = perPage || $('#perPage').val() || 10;
+
+                currentAjaxRequest = $.ajax({
+                    url: "{{ route('admin.users.render-table') }}",
+                    method: 'GET',
+                    data: {
+                        page: page,
+                        per_page: perPage,
+                        ...filters
+                    },
+                    success: function(response) {
+                        const $responseHtml = $(response);
+                        $('#users-table-body-content').html($responseHtml.filter('tbody').html());
+                        $('#users-table-foot-content').html($responseHtml.filter('tfoot').html());
+                    },
+                    error: function(xhr) {
+                        if (xhr.statusText === 'abort') {
+                            return;
+                        }
+                        $('#users-table-body-content').html('<tr><td colspan="6" class="text-center text-danger">Error loading users. Please try again.</td></tr>');
+                    },
+                    complete: function() {
+                        currentAjaxRequest = null;
+                    }
+                });
+            }
+
+            $('#search').on('click', function() {
+                fetchUsersData(1);
+            });
+
+            $('#reset').on('click', function() {
+                $('#filter-form').find('input, select').val('');
+                fetchUsersData(1);
+            });
+
+            $(document).on('click', '#users-table-foot-content a.page-link', function(e) {
+                e.preventDefault();
+                const url = $(this).attr('href');
+                const page = new URL(url).searchParams.get('page');
+                if (page) {
+                    fetchUsersData(page);
+                }
+            });
+
+            $(document).on('change', '#perPage', function() {
+                fetchUsersData(1, $(this).val());
+            });
+        });
+    </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,7 @@ Route::middleware(['auth'])->group(function () {
 
     Route::prefix('admin/users')->name('admin.users.')->group(function () {
         Route::get('list', [UserController::class, 'index'])->name('index');
+        Route::get('render-table', [UserController::class, 'renderUsersTable'])->name('render-table');
         Route::get('create', [UserController::class, 'create'])->name('create');
         Route::post('store', [UserController::class, 'store'])->name('store');
         Route::get('edit/{id}', [UserController::class, 'edit'])->name('edit');


### PR DESCRIPTION
## Summary
- load user list via AJAX like vendor list
- add AJAX-based create & edit forms with client validation
- return JSON responses in `UserController`
- add route for user table rendering

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit -c phpunit.xml --testsuite Unit --stop-on-failure` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6851c9da95708327989b0daf4fe38131