### PR TITLE
Implement role permissions with modules

### DIFF
--- a/config/modules.php
+++ b/config/modules.php
@@ -1,0 +1,9 @@
+<?php
+return [
+    'categories',
+    'vendors',
+    'buyers',
+    'products',
+    'users',
+    'roles'
+];

--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -25,6 +25,23 @@
                                     @endforeach
                                 </select>
                             </div>
+                            <div class="col-md-12">
+                                <label class="form-label">Permissions</label>
+                                <div class="row gy-2">
+                                    @php($actions = $actions ?? ['add','edit','view','export'])
+                                    @foreach ($modules as $module)
+                                        <div class="col-12">
+                                            <strong class="d-block mb-1 text-capitalize">{{ $module }}</strong>
+                                            @foreach ($actions as $action)
+                                                <div class="form-check form-check-inline">
+                                                    <input class="form-check-input" type="checkbox" name="permissions[{{ $module }}][]" value="{{ $action }}" id="{{ $module }}_{{ $action }}">
+                                                    <label class="form-check-label" for="{{ $module }}_{{ $action }}">{{ ucfirst($action) }}</label>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
                         </div>
                         <button type="submit" class="btn btn-primary mt-3">Save Role</button>
                     </form>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -26,6 +26,25 @@
                                     @endforeach
                                 </select>
                             </div>
+                            <div class="col-md-12">
+                                <label class="form-label">Permissions</label>
+                                <div class="row gy-2">
+                                    @php($rolePerms = $role->permissions->keyBy('module'))
+                                    @php($actions = $actions ?? ['add','edit','view','export'])
+                                    @foreach ($modules as $module)
+                                        @php($perm = $rolePerms->get($module))
+                                        <div class="col-12">
+                                            <strong class="d-block mb-1 text-capitalize">{{ $module }}</strong>
+                                            @foreach ($actions as $action)
+                                                <div class="form-check form-check-inline">
+                                                    <input class="form-check-input" type="checkbox" name="permissions[{{ $module }}][]" value="{{ $action }}" id="{{ $module }}_{{ $action }}" @if($perm && $perm->{'can_'.$action}) checked @endif>
+                                                    <label class="form-check-label" for="{{ $module }}_{{ $action }}">{{ ucfirst($action) }}</label>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
                         </div>
                         <button type="submit" class="btn btn-primary mt-3">Update Role</button>
                     </form>


### PR DESCRIPTION
## Summary
- configure modules list
- enable permission selection on role forms
- validate and store module permissions

## Testing
- `composer test` *(fails: composer not found)*
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851ccc7d890832796a2e2690ce5dd9a