### PR TITLE
Implement AJAX role listing

### DIFF
--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -16,6 +16,26 @@ class RoleController extends Controller
         return view('admin.roles.index');
     }
 
+    /**
+     * Render roles table similar to vendors/users list for AJAX pagination.
+     */
+    public function renderRolesTable(Request $request)
+    {
+        $perPage = $request->input('per_page', 10);
+        $page = $request->input('page', 1);
+
+        $query = Role::query()
+            ->with('parent')
+            ->when($request->name, function ($q, $name) {
+                $q->where('name', 'like', "{$name}%");
+            })
+            ->orderBy('name', 'asc');
+
+        $roles = $query->paginate($perPage, ['*'], 'page', $page);
+
+        return view('admin.roles._roles_table', compact('roles'));
+    }
+
     // Fetch roles for DataTable
     public function getRoles()
     {

--- a/resources/views/admin/roles/_roles_table.blade.php
+++ b/resources/views/admin/roles/_roles_table.blade.php
@@ -1,0 +1,24 @@
+{{-- This partial renders roles table body and pagination --}}
+<tbody>
+    @forelse($roles as $index => $role)
+        <tr>
+            <td>{{ ($roles->currentPage() - 1) * $roles->perPage() + $loop->iteration }}</td>
+            <td>{{ htmlspecialchars($role->name) }}</td>
+            <td>{{ $role->parent ? htmlspecialchars($role->parent->name) : '-' }}</td>
+            <td>
+                <a href="{{ route('admin.roles.edit', $role->id) }}" class="btn btn-sm btn-soft-primary" title="Edit">
+                    <iconify-icon icon="solar:pen-2-broken" class="fs-18"></iconify-icon>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="4" class="text-center">No roles found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$roles" />
+    </tr>
+</tfoot>

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -1,19 +1,37 @@
 @extends('admin.layouts.app')
 @section('title', 'Roles | Deal24hours')
 @section('content')
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.5/css/dataTables.bootstrap5.min.css">
     <div class="row">
         <div class="col-xl-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">All Roles</h4>
                     <a href="{{ route('admin.roles.create') }}" class="btn btn-sm btn-primary">
-                        <i class="bi bi-plus-lg" style="font-size: 16px;"></i> Add Role
+                        <i class="bi bi-plus-lg"></i> Add Role
                     </a>
                 </div>
                 <div>
-                    <div class="table-responsive">
-                        <table class="table align-middle mb-0 table-striped table-centered" id="roles-table" style="width: 100%;">
+                    <div class="card-body">
+                        <form id="filter-form" class="row g-2 align-items-end">
+                            <div class="col-md-4">
+                                <label class="form-label" for="name">Role Name</label>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="bi bi-person"></i></span>
+                                    <input type="text" id="name" class="form-control" placeholder="Role Name">
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <button type="button" id="search" class="btn btn-primary">
+                                    <i class="bi bi-search"></i> SEARCH
+                                </button>
+                                <button type="button" id="reset" class="btn btn-outline-danger">
+                                    <i class="bi bi-arrow-clockwise"></i> RESET
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="table-responsive px-4 mb-3">
+                        <table class="table align-middle mb-0 table-striped table-centered" id="roles-table" style="width:100%;">
                             <thead class="bg-light-subtle">
                                 <tr>
                                     <th>#</th>
@@ -22,34 +40,67 @@
                                     <th>Action</th>
                                 </tr>
                             </thead>
-                            <tbody>
-                                <!-- Data loaded via DataTables -->
+                            <tbody id="roles-table-body-content">
+                                <tr>
+                                    <td colspan="4" class="text-center">Loading Roles...</td>
+                                </tr>
                             </tbody>
+                            <tfoot id="roles-table-foot-content">
+                                <tr>
+                                    <td colspan="4" class="text-center"></td>
+                                </tr>
+                            </tfoot>
                         </table>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-    <script src="https://cdn.datatables.net/1.13.5/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.5/js/dataTables.bootstrap5.min.js"></script>
     <script>
-        $(function() {
-            const table = $('#roles-table').DataTable({
-                processing: true,
-                serverSide: true,
-                ajax: {
-                    url: "{{ route('admin.roles.data') }}"
-                },
-                searching: false,
-                lengthChange: false,
-                columns: [
-                    { data: 'id', name: 'id' },
-                    { data: 'name', name: 'name', orderable: false, searchable: false },
-                    { data: 'parent', name: 'parent', orderable: false, searchable: false },
-                    { data: 'action', name: 'action', orderable: false, searchable: false }
-                ]
+        $(document).ready(function() {
+            fetchRolesData(1);
+            var currentAjaxRequest = null;
+            function fetchRolesData(page = 1, perPage = null) {
+                if (currentAjaxRequest && currentAjaxRequest.readyState !== 4) {
+                    currentAjaxRequest.abort();
+                }
+                $('#roles-table-body-content').html('<tr><td colspan="4" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+                $('#roles-table-foot-content').empty();
+                const filters = {
+                    name: $('#name').val()
+                };
+                perPage = perPage || $('#perPage').val() || 10;
+                currentAjaxRequest = $.ajax({
+                    url: "{{ route('admin.roles.render-table') }}",
+                    method: 'GET',
+                    data: {
+                        page: page,
+                        per_page: perPage,
+                        ...filters
+                    },
+                    success: function(response) {
+                        const $responseHtml = $(response);
+                        $('#roles-table-body-content').html($responseHtml.filter('tbody').html());
+                        $('#roles-table-foot-content').html($responseHtml.filter('tfoot').html());
+                    },
+                    error: function(xhr) {
+                        if (xhr.statusText === 'abort') { return; }
+                        $('#roles-table-body-content').html('<tr><td colspan="4" class="text-center text-danger">Error loading roles. Please try again.</td></tr>');
+                    },
+                    complete: function() {
+                        currentAjaxRequest = null;
+                    }
+                });
+            }
+            $('#search').on('click', function() { fetchRolesData(1); });
+            $('#reset').on('click', function() { $('#filter-form').find('input').val(''); fetchRolesData(1); });
+            $(document).on('click', '#roles-table-foot-content a.page-link', function(e) {
+                e.preventDefault();
+                const url = $(this).attr('href');
+                const page = new URL(url).searchParams.get('page');
+                if (page) { fetchRolesData(page); }
             });
+            $(document).on('change', '#perPage', function() { fetchRolesData(1, $(this).val()); });
         });
     </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,7 @@ Route::middleware(['auth'])->group(function () {
     Route::prefix('admin/roles')->name('admin.roles.')->group(function () {
         Route::get('list', [RoleController::class, 'index'])->name('index');
         Route::get('data', [RoleController::class, 'getRoles'])->name('data');
+        Route::get('render-table', [RoleController::class, 'renderRolesTable'])->name('render-table');
         Route::get('create', [RoleController::class, 'create'])->name('create');
         Route::post('store', [RoleController::class, 'store'])->name('store');
         Route::get('edit/{id}', [RoleController::class, 'edit'])->name('edit');


### PR DESCRIPTION
## Summary
- add AJAX-rendered roles table
- implement backend endpoint to serve roles table
- wire up new route
- switch roles index to dynamic table

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6851daa5520c832799e5a65f788e6e64