### PR TITLE
Add admin vendor subscriptions

### DIFF
--- a/app/Http/Controllers/Admin/VendorSubscriptionController.php
+++ b/app/Http/Controllers/Admin/VendorSubscriptionController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\VendorSubscription;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+
+class VendorSubscriptionController extends Controller
+{
+    public function index()
+    {
+        $subscriptions = VendorSubscription::with('user')->latest()->paginate(10);
+        return view('admin.subscriptions.index', compact('subscriptions'));
+    }
+
+    public function create()
+    {
+        $vendors = User::where('role', 'vendor')->orderBy('name')->get();
+        return view('admin.subscriptions.create', compact('vendors'));
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'user_id'    => 'required|exists:users,id',
+            'plan_name'  => 'required|string|max:100',
+            'start_date' => 'required|date',
+            'end_date'   => 'required|date|after_or_equal:start_date',
+            'status'     => 'required|in:active,expired',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        try {
+            VendorSubscription::create($validator->validated());
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 1,
+                    'message' => 'Subscription added successfully!',
+                    'redirect' => route('admin.vendor-subscriptions.index'),
+                ]);
+            }
+        } catch (\Exception $e) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'message' => 'Failed to add subscription: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        return redirect()->route('admin.vendor-subscriptions.index')
+            ->with('success', 'Subscription added successfully!');
+    }
+
+    public function edit($id)
+    {
+        $subscription = VendorSubscription::findOrFail($id);
+        $vendors = User::where('role', 'vendor')->orderBy('name')->get();
+        return view('admin.subscriptions.edit', compact('subscription', 'vendors'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $subscription = VendorSubscription::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'user_id'    => 'required|exists:users,id',
+            'plan_name'  => 'required|string|max:100',
+            'start_date' => 'required|date',
+            'end_date'   => 'required|date|after_or_equal:start_date',
+            'status'     => 'required|in:active,expired',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        try {
+            $subscription->update($validator->validated());
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 1,
+                    'message' => 'Subscription updated successfully!',
+                    'redirect' => route('admin.vendor-subscriptions.index'),
+                ]);
+            }
+        } catch (\Exception $e) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'message' => 'Failed to update subscription: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        return redirect()->route('admin.vendor-subscriptions.index')
+            ->with('success', 'Subscription updated successfully!');
+    }
+}

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -407,6 +407,14 @@
                         </a>
                     </li>
 
+                    <!-- Vendor Subscriptions (single item) -->
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.vendor-subscriptions.index') }}">
+                            <span class="nav-icon"><i class="bi bi-card-checklist"></i></span>
+                            <span class="nav-text"> Vendor Subscriptions </span>
+                        </a>
+                    </li>
+
                     <!-- Buyers Menu (single item) -->
                     <li class="nav-item">
                         <a class="nav-link" href="{{ route('admin.buyers.index') }}">

--- a/resources/views/admin/subscriptions/create.blade.php
+++ b/resources/views/admin/subscriptions/create.blade.php
@@ -1,0 +1,102 @@
+@extends('admin.layouts.app')
+@section('title', 'Add Subscription | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-xl-6">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Add Subscription</h4>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.vendor-subscriptions.store') }}" method="POST" id="subscriptionForm">
+                    @csrf
+                    <div class="mb-3">
+                        <label class="form-label">Vendor <span class="text-danger">*</span></label>
+                        <select name="user_id" id="user_id" class="form-select" required>
+                            <option value="">Select Vendor</option>
+                            @foreach($vendors as $vendor)
+                                <option value="{{ $vendor->id }}">{{ $vendor->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Plan Name <span class="text-danger">*</span></label>
+                        <input type="text" name="plan_name" id="plan_name" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Start Date <span class="text-danger">*</span></label>
+                        <input type="date" name="start_date" id="start_date" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">End Date <span class="text-danger">*</span></label>
+                        <input type="date" name="end_date" id="end_date" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Status <span class="text-danger">*</span></label>
+                        <select name="status" id="status" class="form-select">
+                            <option value="active">Active</option>
+                            <option value="expired">Expired</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a href="{{ route('admin.vendor-subscriptions.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('#subscriptionForm').find('select, input').each(function(){
+            if(!$(this).val()){
+                $(this).addClass('is-invalid');
+                ok = false;
+            }else{
+                $(this).removeClass('is-invalid');
+            }
+        });
+        return ok;
+    }
+    $('#subscriptionForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var $form = $(this);
+        var $btn = $form.find('button[type="submit"]');
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            beforeSend: function(){
+                $btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm"></span> Saving...');
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(function(){ window.location.href = res.redirect; }, 1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete: function(){
+                $btn.prop('disabled', false).html('Save');
+            }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/subscriptions/edit.blade.php
+++ b/resources/views/admin/subscriptions/edit.blade.php
@@ -1,0 +1,103 @@
+@extends('admin.layouts.app')
+@section('title', 'Edit Subscription | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-xl-6">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Edit Subscription</h4>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.vendor-subscriptions.update', $subscription->id) }}" method="POST" id="subscriptionForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="mb-3">
+                        <label class="form-label">Vendor <span class="text-danger">*</span></label>
+                        <select name="user_id" id="user_id" class="form-select" required>
+                            <option value="">Select Vendor</option>
+                            @foreach($vendors as $vendor)
+                                <option value="{{ $vendor->id }}" {{ $subscription->user_id == $vendor->id ? 'selected' : '' }}>{{ $vendor->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Plan Name <span class="text-danger">*</span></label>
+                        <input type="text" name="plan_name" id="plan_name" class="form-control" value="{{ $subscription->plan_name }}" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Start Date <span class="text-danger">*</span></label>
+                        <input type="date" name="start_date" id="start_date" class="form-control" value="{{ $subscription->start_date }}" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">End Date <span class="text-danger">*</span></label>
+                        <input type="date" name="end_date" id="end_date" class="form-control" value="{{ $subscription->end_date }}" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Status <span class="text-danger">*</span></label>
+                        <select name="status" id="status" class="form-select">
+                            <option value="active" {{ $subscription->status == 'active' ? 'selected' : '' }}>Active</option>
+                            <option value="expired" {{ $subscription->status == 'expired' ? 'selected' : '' }}>Expired</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Update</button>
+                    <a href="{{ route('admin.vendor-subscriptions.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('#subscriptionForm').find('select, input').each(function(){
+            if(!$(this).val()){
+                $(this).addClass('is-invalid');
+                ok = false;
+            }else{
+                $(this).removeClass('is-invalid');
+            }
+        });
+        return ok;
+    }
+    $('#subscriptionForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var $form = $(this);
+        var $btn = $form.find('button[type="submit"]');
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            beforeSend: function(){
+                $btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm"></span> Updating...');
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(function(){ window.location.href = res.redirect; }, 1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete: function(){
+                $btn.prop('disabled', false).html('Update');
+            }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/subscriptions/index.blade.php
+++ b/resources/views/admin/subscriptions/index.blade.php
@@ -1,0 +1,57 @@
+@extends('admin.layouts.app')
+@section('title', 'Vendor Subscriptions | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-xl-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1 mb-0">Vendor Subscriptions</h4>
+                <a href="{{ route('admin.vendor-subscriptions.create') }}" class="btn btn-primary btn-sm">
+                    <i class="bi bi-plus"></i> Add Subscription
+                </a>
+            </div>
+            <div class="card-body table-responsive">
+                <table class="table table-striped">
+                    <thead class="bg-light-subtle">
+                        <tr>
+                            <th>#</th>
+                            <th>Vendor</th>
+                            <th>Plan</th>
+                            <th>Start</th>
+                            <th>End</th>
+                            <th>Status</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($subscriptions as $subscription)
+                            <tr>
+                                <td>{{ $loop->iteration }}</td>
+                                <td>{{ $subscription->user->name }}</td>
+                                <td>{{ $subscription->plan_name }}</td>
+                                <td>{{ $subscription->start_date }}</td>
+                                <td>{{ $subscription->end_date }}</td>
+                                <td>
+                                    <span class="badge {{ $subscription->status == 'active' ? 'bg-success' : 'bg-danger' }}">
+                                        {{ ucfirst($subscription->status) }}
+                                    </span>
+                                </td>
+                                <td>
+                                    <a href="{{ route('admin.vendor-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center">No subscriptions found.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+                {{ $subscriptions->links() }}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,14 @@ Route::middleware(['auth'])->group(function () {
         Route::delete('{id}', [VendorExportController::class, 'destroy'])->name('destroy');
     });
 
+    Route::prefix('admin/vendor-subscriptions')->name('admin.vendor-subscriptions.')->group(function () {
+        Route::get('/', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'index'])->name('index');
+        Route::get('create', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'create'])->name('create');
+        Route::post('store', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'store'])->name('store');
+        Route::get('{id}/edit', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'edit'])->name('edit');
+        Route::put('{id}', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'update'])->name('update');
+    });
+
     Route::prefix('admin/roles')->name('admin.roles.')->group(function () {
         Route::get('list', [RoleController::class, 'index'])->name('index');
         Route::get('data', [RoleController::class, 'getRoles'])->name('data');


### PR DESCRIPTION
## Summary
- add `VendorSubscriptionController` for admin panel
- create views for listing and managing vendor subscriptions
- register routes and navigation link

## Testing
- `php artisan --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852acc2f3b083278ee2f566968a8591