### PR TITLE
Enable AJAX vendor search in subscriptions

### DIFF
--- a/app/Http/Controllers/Admin/VendorSubscriptionController.php
+++ b/app/Http/Controllers/Admin/VendorSubscriptionController.php
@@ -18,8 +18,9 @@ class VendorSubscriptionController extends Controller
 
     public function create()
     {
-        $vendors = User::where('role', 'vendor')->orderBy('name')->get();
-        return view('admin.subscriptions.create', compact('vendors'));
+        // Do not preload all vendors to avoid loading millions of records.
+        // The vendor dropdown will fetch data via AJAX.
+        return view('admin.subscriptions.create');
     }
 
     public function store(Request $request)
@@ -66,9 +67,10 @@ class VendorSubscriptionController extends Controller
 
     public function edit($id)
     {
-        $subscription = VendorSubscription::findOrFail($id);
-        $vendors = User::where('role', 'vendor')->orderBy('name')->get();
-        return view('admin.subscriptions.edit', compact('subscription', 'vendors'));
+        $subscription = VendorSubscription::with('user:id,name')->findOrFail($id);
+        // Pass only the current vendor to the view for the preselected option.
+        $vendor = $subscription->user;
+        return view('admin.subscriptions.edit', compact('subscription', 'vendor'));
     }
 
     public function update(Request $request, $id)

--- a/resources/views/admin/products/approved.blade.php
+++ b/resources/views/admin/products/approved.blade.php
@@ -212,7 +212,7 @@
             placeholder: 'Search vendor',
             allowClear: true,
             ajax: {
-                url: "{{ route('admin.vendor.search') }}",
+                url: "{{ route('admin.vendors.search') }}",
                 dataType: 'json',
                 delay: 250,
                 data: function(params) {

--- a/resources/views/admin/products/pending.blade.php
+++ b/resources/views/admin/products/pending.blade.php
@@ -212,7 +212,7 @@
             placeholder: 'Search vendor',
             allowClear: true,
             ajax: {
-                url: "{{ route('admin.vendor.search') }}",
+                url: "{{ route('admin.vendors.search') }}",
                 dataType: 'json',
                 delay: 250,
                 data: function(params) {

--- a/resources/views/admin/products/rejected.blade.php
+++ b/resources/views/admin/products/rejected.blade.php
@@ -212,7 +212,7 @@
             placeholder: 'Search vendor',
             allowClear: true,
             ajax: {
-                url: "{{ route('admin.vendor.search') }}",
+                url: "{{ route('admin.vendors.search') }}",
                 dataType: 'json',
                 delay: 250,
                 data: function(params) {

--- a/resources/views/admin/subscriptions/create.blade.php
+++ b/resources/views/admin/subscriptions/create.blade.php
@@ -12,11 +12,8 @@
                     @csrf
                     <div class="mb-3">
                         <label class="form-label">Vendor <span class="text-danger">*</span></label>
-                        <select name="user_id" id="user_id" class="form-select" required>
-                            <option value="">Select Vendor</option>
-                            @foreach($vendors as $vendor)
-                                <option value="{{ $vendor->id }}">{{ $vendor->name }}</option>
-                            @endforeach
+                        <select name="user_id" id="user_id" class="form-select select2" style="width:100%" required>
+                            <option value="">Search Vendor</option>
                         </select>
                     </div>
                     <div class="mb-3">
@@ -45,6 +42,8 @@
         </div>
     </div>
 </div>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
 $(function(){
     function validateForm(){
@@ -96,6 +95,30 @@ $(function(){
                 $btn.prop('disabled', false).html('Save');
             }
         });
+    });
+
+    // Initialize Select2 for vendor search
+    $('#user_id').select2({
+        placeholder: 'Search Vendor',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('admin.vendors.search') }}",
+            dataType: 'json',
+            delay: 250,
+            data: function(params){
+                return {
+                    q: params.term
+                };
+            },
+            processResults: function(data){
+                return {
+                    results: data.map(function(item){
+                        return { id: item.id, text: item.name };
+                    })
+                };
+            },
+            cache: true
+        }
     });
 });
 </script>

--- a/resources/views/admin/subscriptions/edit.blade.php
+++ b/resources/views/admin/subscriptions/edit.blade.php
@@ -13,11 +13,12 @@
                     @method('PUT')
                     <div class="mb-3">
                         <label class="form-label">Vendor <span class="text-danger">*</span></label>
-                        <select name="user_id" id="user_id" class="form-select" required>
-                            <option value="">Select Vendor</option>
-                            @foreach($vendors as $vendor)
-                                <option value="{{ $vendor->id }}" {{ $subscription->user_id == $vendor->id ? 'selected' : '' }}>{{ $vendor->name }}</option>
-                            @endforeach
+                        <select name="user_id" id="user_id" class="form-select select2" style="width:100%" required>
+                            @if(isset($vendor))
+                                <option value="{{ $vendor->id }}" selected>{{ $vendor->name }}</option>
+                            @else
+                                <option value="">Search Vendor</option>
+                            @endif
                         </select>
                     </div>
                     <div class="mb-3">
@@ -46,6 +47,8 @@
         </div>
     </div>
 </div>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
 $(function(){
     function validateForm(){
@@ -97,6 +100,28 @@ $(function(){
                 $btn.prop('disabled', false).html('Update');
             }
         });
+    });
+
+    // Initialize Select2 for vendor search
+    $('#user_id').select2({
+        placeholder: 'Search Vendor',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('admin.vendors.search') }}",
+            dataType: 'json',
+            delay: 250,
+            data: function(params){
+                return { q: params.term };
+            },
+            processResults: function(data){
+                return {
+                    results: data.map(function(item){
+                        return { id: item.id, text: item.name };
+                    })
+                };
+            },
+            cache: true
+        }
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- avoid loading millions of vendors by fetching via AJAX
- update subscription create/edit pages to use Select2
- fix vendor search route name on product pages

## Testing
- `composer install --no-interaction` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852b05e69c883278014f8a4c9bdb8bf