### PR TITLE
Add plan CRUD with AJAX validation

### DIFF
--- a/app/Http/Controllers/Admin/PlanController.php
+++ b/app/Http/Controllers/Admin/PlanController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Plan;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class PlanController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $plans = Plan::latest()->paginate(10);
+        return view('admin.plans.index', compact('plans'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('admin.plans.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:100',
+            'price' => 'required|numeric|min:0',
+            'plan_for' => 'required|in:vendor,buyer',
+            'status' => 'required|in:active,inactive',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json(['status' => 0, 'errors' => $validator->errors()], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        Plan::create($validator->validated());
+
+        if ($request->ajax()) {
+            return response()->json([
+                'status' => 1,
+                'message' => 'Plan added successfully!',
+                'redirect' => route('admin.plans.index'),
+            ]);
+        }
+
+        return redirect()->route('admin.plans.index')->with('success', 'Plan added successfully!');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Plan $plan)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Plan $plan)
+    {
+        return view('admin.plans.edit', compact('plan'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Plan $plan)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:100',
+            'price' => 'required|numeric|min:0',
+            'plan_for' => 'required|in:vendor,buyer',
+            'status' => 'required|in:active,inactive',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json(['status' => 0, 'errors' => $validator->errors()], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $plan->update($validator->validated());
+
+        if ($request->ajax()) {
+            return response()->json([
+                'status' => 1,
+                'message' => 'Plan updated successfully!',
+                'redirect' => route('admin.plans.index'),
+            ]);
+        }
+
+        return redirect()->route('admin.plans.index')->with('success', 'Plan updated successfully!');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Plan $plan)
+    {
+        //
+    }
+}

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Plan extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'price',
+        'plan_for',
+        'status',
+    ];
+}

--- a/database/migrations/2025_06_18_142527_create_plans_table.php
+++ b/database/migrations/2025_06_18_142527_create_plans_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plans', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->decimal('price', 10, 2);
+            $table->enum('plan_for', ['vendor', 'buyer']);
+            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('plans');
+    }
+};

--- a/resources/views/admin/plans/create.blade.php
+++ b/resources/views/admin/plans/create.blade.php
@@ -1,0 +1,100 @@
+@extends('admin.layouts.app')
+@section('title', 'Add Plan | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Add Plan</h4>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.plans.store') }}" method="POST" id="planForm">
+                    @csrf
+                    <div class="row gy-3">
+                        <div class="col-md-12">
+                            <label class="form-label">Name <span class="text-danger">*</span></label>
+                            <input type="text" name="name" id="name" class="form-control" required>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Price <span class="text-danger">*</span></label>
+                            <input type="number" step="0.01" name="price" id="price" class="form-control" required>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Plan For <span class="text-danger">*</span></label>
+                            <select name="plan_for" id="plan_for" class="form-select">
+                                <option value="vendor">Vendor</option>
+                                <option value="buyer">Buyer</option>
+                            </select>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Status <span class="text-danger">*</span></label>
+                            <select name="status" id="status" class="form-select">
+                                <option value="active">Active</option>
+                                <option value="inactive">Inactive</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                        <a href="{{ route('admin.plans.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('#planForm').find('input, select').each(function(){
+            if(!$(this).val()){
+                $(this).addClass('is-invalid');
+                ok = false;
+            }else{
+                $(this).removeClass('is-invalid');
+            }
+        });
+        return ok;
+    }
+    $('#planForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var $form = $(this);
+        var $btn = $form.find('button[type="submit"]');
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            beforeSend: function(){
+                $btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm"></span> Saving...');
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(function(){ window.location.href = res.redirect; }, 1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete: function(){
+                $btn.prop('disabled', false).html('Save');
+            }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/plans/edit.blade.php
+++ b/resources/views/admin/plans/edit.blade.php
@@ -1,0 +1,101 @@
+@extends('admin.layouts.app')
+@section('title', 'Edit Plan | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Edit Plan</h4>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.plans.update', $plan->id) }}" method="POST" id="planForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="row gy-3">
+                        <div class="col-md-12">
+                            <label class="form-label">Name <span class="text-danger">*</span></label>
+                            <input type="text" name="name" id="name" class="form-control" value="{{ $plan->name }}" required>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Price <span class="text-danger">*</span></label>
+                            <input type="number" step="0.01" name="price" id="price" class="form-control" value="{{ $plan->price }}" required>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Plan For <span class="text-danger">*</span></label>
+                            <select name="plan_for" id="plan_for" class="form-select">
+                                <option value="vendor" {{ $plan->plan_for == 'vendor' ? 'selected' : '' }}>Vendor</option>
+                                <option value="buyer" {{ $plan->plan_for == 'buyer' ? 'selected' : '' }}>Buyer</option>
+                            </select>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Status <span class="text-danger">*</span></label>
+                            <select name="status" id="status" class="form-select">
+                                <option value="active" {{ $plan->status == 'active' ? 'selected' : '' }}>Active</option>
+                                <option value="inactive" {{ $plan->status == 'inactive' ? 'selected' : '' }}>Inactive</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                        <a href="{{ route('admin.plans.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('#planForm').find('input, select').each(function(){
+            if(!$(this).val()){
+                $(this).addClass('is-invalid');
+                ok = false;
+            }else{
+                $(this).removeClass('is-invalid');
+            }
+        });
+        return ok;
+    }
+    $('#planForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var $form = $(this);
+        var $btn = $form.find('button[type="submit"]');
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            beforeSend: function(){
+                $btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm"></span> Updating...');
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(function(){ window.location.href = res.redirect; }, 1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete: function(){
+                $btn.prop('disabled', false).html('Update');
+            }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/plans/index.blade.php
+++ b/resources/views/admin/plans/index.blade.php
@@ -1,0 +1,55 @@
+@extends('admin.layouts.app')
+@section('title', 'Plans | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-xl-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1 mb-0">Plans</h4>
+                <a href="{{ route('admin.plans.create') }}" class="btn btn-primary btn-sm">
+                    <i class="bi bi-plus"></i> Add Plan
+                </a>
+            </div>
+            <div class="card-body table-responsive">
+                <table class="table table-striped">
+                    <thead class="bg-light-subtle">
+                        <tr>
+                            <th>#</th>
+                            <th>Name</th>
+                            <th>Price</th>
+                            <th>For</th>
+                            <th>Status</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($plans as $plan)
+                            <tr>
+                                <td>{{ $loop->iteration }}</td>
+                                <td>{{ $plan->name }}</td>
+                                <td>{{ $plan->price }}</td>
+                                <td>{{ ucfirst($plan->plan_for) }}</td>
+                                <td>
+                                    <span class="badge {{ $plan->status == 'active' ? 'bg-success' : 'bg-danger' }}">
+                                        {{ ucfirst($plan->status) }}
+                                    </span>
+                                </td>
+                                <td>
+                                    <a href="{{ route('admin.plans.edit', $plan->id) }}" class="btn btn-soft-primary btn-sm">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center">No plans found.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+                {{ $plans->links() }}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,6 +89,14 @@ Route::middleware(['auth'])->group(function () {
         Route::put('{id}', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'update'])->name('update');
     });
 
+    Route::prefix('admin/plans')->name('admin.plans.')->group(function () {
+        Route::get('/', [App\Http\Controllers\Admin\PlanController::class, 'index'])->name('index');
+        Route::get('create', [App\Http\Controllers\Admin\PlanController::class, 'create'])->name('create');
+        Route::post('store', [App\Http\Controllers\Admin\PlanController::class, 'store'])->name('store');
+        Route::get('{plan}/edit', [App\Http\Controllers\Admin\PlanController::class, 'edit'])->name('edit');
+        Route::put('{plan}', [App\Http\Controllers\Admin\PlanController::class, 'update'])->name('update');
+    });
+
     Route::prefix('admin/roles')->name('admin.roles.')->group(function () {
         Route::get('list', [RoleController::class, 'index'])->name('index');
         Route::get('data', [RoleController::class, 'getRoles'])->name('data');


### PR DESCRIPTION
## Summary
- add migration and model for plans
- implement PlanController with AJAX validation
- create admin views for listing and editing plans
- hook up plan routes

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6852cbd3ddc48327959dff067e5fb55c