### PR TITLE
Add plan menu link

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -415,6 +415,14 @@
                         </a>
                     </li>
 
+                    <!-- Plans Menu (single item) -->
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.plans.index') }}">
+                            <span class="nav-icon"><i class="bi bi-card-list"></i></span>
+                            <span class="nav-text"> Plans </span>
+                        </a>
+                    </li>
+
                     <!-- Buyers Menu (single item) -->
                     <li class="nav-item">
                         <a class="nav-link" href="{{ route('admin.buyers.index') }}">


### PR DESCRIPTION
## Summary
- add a menu entry in the admin sidebar that links to Plans

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6852cec222fc8327bc920bcd99d7a3e2