### PR TITLE
Fix VendorSubscription duration type and unify admin layout

### DIFF
--- a/app/Http/Controllers/Admin/VendorSubscriptionController.php
+++ b/app/Http/Controllers/Admin/VendorSubscriptionController.php
@@ -49,9 +49,10 @@ class VendorSubscriptionController extends Controller
 
         try {
             $data = $validator->validated();
+            $duration = (int) $data['duration'];
             $start = Carbon::now();
             $data['start_date'] = $start->toDateString();
-            $data['end_date'] = $start->copy()->addMonths($request->duration)->toDateString();
+            $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
             unset($data['duration']);
             VendorSubscription::create($data);
             if ($request->ajax()) {
@@ -111,9 +112,10 @@ class VendorSubscriptionController extends Controller
 
         try {
             $data = $validator->validated();
+            $duration = (int) $data['duration'];
             $start = Carbon::now();
             $data['start_date'] = $start->toDateString();
-            $data['end_date'] = $start->copy()->addMonths($request->duration)->toDateString();
+            $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
             unset($data['duration']);
             $subscription->update($data);
             if ($request->ajax()) {

--- a/app/Http/Controllers/Vendor/VendorSubscriptionController.php
+++ b/app/Http/Controllers/Vendor/VendorSubscriptionController.php
@@ -40,9 +40,10 @@ class VendorSubscriptionController extends Controller
         }
 
         $data = $validator->validated();
+        $duration = (int) $data['duration'];
         $start = Carbon::now();
         $data['start_date'] = $start->toDateString();
-        $data['end_date'] = $start->copy()->addMonths($request->duration)->toDateString();
+        $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
         unset($data['duration']);
         $user = Auth::user();
         $subscription = $user->subscription;

--- a/resources/views/admin/subscriptions/edit.blade.php
+++ b/resources/views/admin/subscriptions/edit.blade.php
@@ -2,7 +2,7 @@
 @section('title', 'Edit Subscription | Deal24hours')
 @section('content')
 <div class="row">
-    <div class="col-xl-6">
+    <div class="col-md-12">
         <div class="card">
             <div class="card-header">
                 <h4 class="card-title mb-0">Edit Subscription</h4>


### PR DESCRIPTION
## Summary
- enforce integer duration when calculating subscription dates
- adjust admin subscription update layout to use a full-width card

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d608a64c8327bd1ca750c99b1db5