### PR TITLE
Add buyer subscription management

### DIFF
--- a/app/Http/Controllers/Admin/BuyerController.php
+++ b/app/Http/Controllers/Admin/BuyerController.php
@@ -98,6 +98,20 @@ class BuyerController extends Controller
         return view('admin.buyers._buyers_table', compact('buyers'));
     }
 
+    /**
+     * Search buyers for select2 dropdown.
+     */
+    public function search(Request $request)
+    {
+        $search = $request->get('q');
+        $buyers = User::where('role', 'buyer')
+            ->where('name', 'like', '%' . $search . '%')
+            ->limit(20)
+            ->get(['id', 'name']);
+
+        return response()->json($buyers);
+    }
+
     // Show create buyer form
     public function create()
     {

--- a/app/Http/Controllers/Admin/BuyerSubscriptionController.php
+++ b/app/Http/Controllers/Admin/BuyerSubscriptionController.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\BuyerSubscription;
+use App\Models\User;
+use App\Models\Plan;
+use Illuminate\Support\Facades\Validator;
+use Carbon\Carbon;
+
+class BuyerSubscriptionController extends Controller
+{
+    public function index()
+    {
+        $subscriptions = BuyerSubscription::with('user')->latest()->paginate(10);
+        return view('admin.buyer_subscriptions.index', compact('subscriptions'));
+    }
+
+    public function create()
+    {
+        $plans = Plan::where('status', 'active')
+            ->where('plan_for', 'buyer')
+            ->pluck('name');
+        return view('admin.buyer_subscriptions.create', compact('plans'));
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'user_id'   => 'required|exists:users,id',
+            'plan_name' => 'required|exists:plans,name',
+            'duration'  => 'required|integer|min:1|max:24',
+            'status'    => 'required|in:active,expired',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        try {
+            $data = $validator->validated();
+            $duration = (int) $data['duration'];
+            $start = Carbon::now();
+            $data['start_date'] = $start->toDateString();
+            $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
+            unset($data['duration']);
+            BuyerSubscription::create($data);
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 1,
+                    'message' => 'Subscription added successfully!',
+                    'redirect' => route('admin.buyer-subscriptions.index'),
+                ]);
+            }
+        } catch (\Exception $e) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'message' => 'Failed to add subscription: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        return redirect()->route('admin.buyer-subscriptions.index')
+            ->with('success', 'Subscription added successfully!');
+    }
+
+    public function edit($id)
+    {
+        $subscription = BuyerSubscription::with('user:id,name')->findOrFail($id);
+        $buyer = $subscription->user;
+        $plans = Plan::where('status', 'active')
+            ->where('plan_for', 'buyer')
+            ->pluck('name');
+        $duration = $subscription->start_date && $subscription->end_date
+            ? Carbon::parse($subscription->start_date)->diffInMonths(Carbon::parse($subscription->end_date))
+            : 1;
+        return view('admin.buyer_subscriptions.edit', compact('subscription', 'buyer', 'plans', 'duration'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $subscription = BuyerSubscription::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'user_id'   => 'required|exists:users,id',
+            'plan_name' => 'required|exists:plans,name',
+            'duration'  => 'required|integer|min:1|max:24',
+            'status'    => 'required|in:active,expired',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        try {
+            $data = $validator->validated();
+            $duration = (int) $data['duration'];
+            $start = Carbon::now();
+            $data['start_date'] = $start->toDateString();
+            $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
+            unset($data['duration']);
+            $subscription->update($data);
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 1,
+                    'message' => 'Subscription updated successfully!',
+                    'redirect' => route('admin.buyer-subscriptions.index'),
+                ]);
+            }
+        } catch (\Exception $e) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'message' => 'Failed to update subscription: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        return redirect()->route('admin.buyer-subscriptions.index')
+            ->with('success', 'Subscription updated successfully!');
+    }
+}

--- a/app/Models/BuyerSubscription.php
+++ b/app/Models/BuyerSubscription.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BuyerSubscription extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'plan_name',
+        'start_date',
+        'end_date',
+        'status',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_06_18_150000_create_buyer_subscriptions_table.php
+++ b/database/migrations/2025_06_18_150000_create_buyer_subscriptions_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('buyer_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('plan_name', 100);
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            $table->enum('status', ['active', 'expired'])->default('active');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('buyer_subscriptions');
+    }
+};

--- a/resources/views/admin/buyer_subscriptions/create.blade.php
+++ b/resources/views/admin/buyer_subscriptions/create.blade.php
@@ -1,0 +1,133 @@
+@extends('admin.layouts.app')
+@section('title', 'Add Buyer Subscription | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Add Buyer Subscription</h4>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.buyer-subscriptions.store') }}" method="POST" id="subscriptionForm">
+                    @csrf
+                    <div class="row gy-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Buyer <span class="text-danger">*</span></label>
+                            <select name="user_id" id="user_id" class="form-select select2" style="width:100%" required>
+                                <option value="">Search Buyer</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Plan Name <span class="text-danger">*</span></label>
+                            <select name="plan_name" id="plan_name" class="form-select" required>
+                                <option value="">Select Plan</option>
+                                @foreach($plans as $plan)
+                                    <option value="{{ $plan }}">{{ $plan }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Duration <span class="text-danger">*</span></label>
+                            <select name="duration" id="duration" class="form-select" required>
+                                @for($i = 1; $i <= 24; $i++)
+                                    <option value="{{ $i }}">{{ $i }} Month{{ $i > 1 ? 's' : '' }}</option>
+                                @endfor
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Status <span class="text-danger">*</span></label>
+                            <select name="status" id="status" class="form-select">
+                                <option value="active">Active</option>
+                                <option value="expired">Expired</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                        <a href="{{ route('admin.buyer-subscriptions.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('#subscriptionForm').find('select, input').each(function(){
+            if(!$(this).val()){
+                $(this).addClass('is-invalid');
+                ok = false;
+            }else{
+                $(this).removeClass('is-invalid');
+            }
+        });
+        return ok;
+    }
+    $('#subscriptionForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var $form = $(this);
+        var $btn = $form.find('button[type="submit"]');
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            beforeSend: function(){
+                $btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm"></span> Saving...');
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(function(){ window.location.href = res.redirect; }, 1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete: function(){
+                $btn.prop('disabled', false).html('Save');
+            }
+        });
+    });
+
+    $('#user_id').select2({
+        placeholder: 'Search Buyer',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('admin.buyers.search') }}",
+            dataType: 'json',
+            delay: 250,
+            data: function(params){
+                return {
+                    q: params.term
+                };
+            },
+            processResults: function(data){
+                return {
+                    results: data.map(function(item){
+                        return { id: item.id, text: item.name };
+                    })
+                };
+            },
+            cache: true
+        }
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/buyer_subscriptions/edit.blade.php
+++ b/resources/views/admin/buyer_subscriptions/edit.blade.php
@@ -1,0 +1,136 @@
+@extends('admin.layouts.app')
+@section('title', 'Edit Buyer Subscription | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Edit Buyer Subscription</h4>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.buyer-subscriptions.update', $subscription->id) }}" method="POST" id="subscriptionForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="row gy-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Buyer <span class="text-danger">*</span></label>
+                            <select name="user_id" id="user_id" class="form-select select2" style="width:100%" required>
+                                @if(isset($buyer))
+                                    <option value="{{ $buyer->id }}" selected>{{ $buyer->name }}</option>
+                                @else
+                                    <option value="">Search Buyer</option>
+                                @endif
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Plan Name <span class="text-danger">*</span></label>
+                            <select name="plan_name" id="plan_name" class="form-select" required>
+                                <option value="">Select Plan</option>
+                                @foreach($plans as $plan)
+                                    <option value="{{ $plan }}" {{ $subscription->plan_name == $plan ? 'selected' : '' }}>{{ $plan }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Duration <span class="text-danger">*</span></label>
+                            <select name="duration" id="duration" class="form-select" required>
+                                @for($i = 1; $i <= 24; $i++)
+                                    <option value="{{ $i }}" {{ $duration == $i ? 'selected' : '' }}>{{ $i }} Month{{ $i > 1 ? 's' : '' }}</option>
+                                @endfor
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Status <span class="text-danger">*</span></label>
+                            <select name="status" id="status" class="form-select">
+                                <option value="active" {{ $subscription->status == 'active' ? 'selected' : '' }}>Active</option>
+                                <option value="expired" {{ $subscription->status == 'expired' ? 'selected' : '' }}>Expired</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                        <a href="{{ route('admin.buyer-subscriptions.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('#subscriptionForm').find('select, input').each(function(){
+            if(!$(this).val()){
+                $(this).addClass('is-invalid');
+                ok = false;
+            }else{
+                $(this).removeClass('is-invalid');
+            }
+        });
+        return ok;
+    }
+    $('#subscriptionForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var $form = $(this);
+        var $btn = $form.find('button[type="submit"]');
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            beforeSend: function(){
+                $btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm"></span> Updating...');
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(function(){ window.location.href = res.redirect; }, 1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete: function(){
+                $btn.prop('disabled', false).html('Update');
+            }
+        });
+    });
+
+    $('#user_id').select2({
+        placeholder: 'Search Buyer',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('admin.buyers.search') }}",
+            dataType: 'json',
+            delay: 250,
+            data: function(params){
+                return { q: params.term };
+            },
+            processResults: function(data){
+                return {
+                    results: data.map(function(item){
+                        return { id: item.id, text: item.name };
+                    })
+                };
+            },
+            cache: true
+        }
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/buyer_subscriptions/index.blade.php
+++ b/resources/views/admin/buyer_subscriptions/index.blade.php
@@ -1,12 +1,12 @@
 @extends('admin.layouts.app')
-@section('title', 'Vendor Subscriptions | Deal24hours')
+@section('title', 'Buyer Subscriptions | Deal24hours')
 @section('content')
 <div class="row">
     <div class="col-xl-12">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center gap-1">
-                <h4 class="card-title flex-grow-1 mb-0">Vendor Subscriptions</h4>
-                <a href="{{ route('admin.vendor-subscriptions.create') }}" class="btn btn-primary btn-sm">
+                <h4 class="card-title flex-grow-1 mb-0">Buyer Subscriptions</h4>
+                <a href="{{ route('admin.buyer-subscriptions.create') }}" class="btn btn-primary btn-sm">
                     <i class="bi bi-plus"></i> Add Subscription
                 </a>
             </div>
@@ -15,7 +15,7 @@
                     <thead class="bg-light-subtle">
                         <tr>
                             <th>#</th>
-                            <th>Vendor</th>
+                            <th>Buyer</th>
                             <th>Plan</th>
                             <th>Start</th>
                             <th>End</th>
@@ -37,7 +37,7 @@
                                     </span>
                                 </td>
                                 <td>
-                                    <a href="{{ route('admin.vendor-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm">
+                                    <a href="{{ route('admin.buyer-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm">
                                         <i class="bi bi-pencil"></i>
                                     </a>
                                 </td>

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -415,6 +415,14 @@
                         </a>
                     </li>
 
+                    <!-- Buyer Subscriptions (single item) -->
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.buyer-subscriptions.index') }}">
+                            <span class="nav-icon"><i class="bi bi-card-checklist"></i></span>
+                            <span class="nav-text"> Buyer Subscriptions </span>
+                        </a>
+                    </li>
+
                     <!-- Plans Menu (single item) -->
                     <li class="nav-item">
                         <a class="nav-link" href="{{ route('admin.plans.index') }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,6 +89,14 @@ Route::middleware(['auth'])->group(function () {
         Route::put('{id}', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'update'])->name('update');
     });
 
+    Route::prefix('admin/buyer-subscriptions')->name('admin.buyer-subscriptions.')->group(function () {
+        Route::get('/', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'index'])->name('index');
+        Route::get('create', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'create'])->name('create');
+        Route::post('store', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'store'])->name('store');
+        Route::get('{id}/edit', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'edit'])->name('edit');
+        Route::put('{id}', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'update'])->name('update');
+    });
+
     Route::prefix('admin/plans')->name('admin.plans.')->group(function () {
         Route::get('/', [App\Http\Controllers\Admin\PlanController::class, 'index'])->name('index');
         Route::get('create', [App\Http\Controllers\Admin\PlanController::class, 'create'])->name('create');
@@ -120,6 +128,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('list', [BuyerController::class, 'index'])->name('index');
         Route::get('data', [BuyerController::class, 'getBuyers'])->name('data');
         Route::get('render-table', [BuyerController::class, 'renderBuyersTable'])->name('render-table');
+        Route::get('search', [BuyerController::class, 'search'])->name('search');
         Route::get('create', [BuyerController::class, 'create'])->name('create');
         Route::post('store', [BuyerController::class, 'store'])->name('store');
         Route::get('edit/{id}', [BuyerController::class, 'edit'])->name('edit');


### PR DESCRIPTION
## Summary
- create BuyerSubscription model and migration
- implement admin controller with AJAX validation
- add buyer-subscriptions routes and menu
- add CRUD views for buyer subscriptions with select2 search
- allow searching buyers and display subscription dates in dd-mm-yyyy format

## Testing
- `php` not installed so PHPUnit tests could not run

------
https://chatgpt.com/codex/tasks/task_e_6853a33737f08327beea971103f827f4