### PR TITLE
Update menu order and date filters

### DIFF
--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Spatie\Activitylog\Models\Activity;
 use Illuminate\Http\Request;
 use Yajra\DataTables\DataTables;
+use Carbon\Carbon;
 
 class ActivityLogController extends Controller
 {
@@ -18,10 +19,12 @@ class ActivityLogController extends Controller
                 return $query->where('subject_type', $type);
             })
             ->when($request->date_from, function($query, $date) {
-                return $query->whereDate('created_at', '>=', $date);
+                $from = Carbon::createFromFormat('d-m-Y', $date)->format('Y-m-d');
+                return $query->whereDate('created_at', '>=', $from);
             })
             ->when($request->date_to, function($query, $date) {
-                return $query->whereDate('created_at', '<=', $date);
+                $to = Carbon::createFromFormat('d-m-Y', $date)->format('Y-m-d');
+                return $query->whereDate('created_at', '<=', $to);
             })
             ->latest()
             ->paginate(20);
@@ -46,10 +49,12 @@ class ActivityLogController extends Controller
                 return $query->where('subject_type', $type);
             })
             ->when($request->date_from, function($query, $date) {
-                return $query->whereDate('created_at', '>=', $date);
+                $from = Carbon::createFromFormat('d-m-Y', $date)->format('Y-m-d');
+                return $query->whereDate('created_at', '>=', $from);
             })
             ->when($request->date_to, function($query, $date) {
-                return $query->whereDate('created_at', '<=', $date);
+                $to = Carbon::createFromFormat('d-m-Y', $date)->format('Y-m-d');
+                return $query->whereDate('created_at', '<=', $to);
             })
             ->orderBy('created_at', 'desc');
 
@@ -65,7 +70,7 @@ class ActivityLogController extends Controller
                 return $log->subject ? class_basename($log->subject).' #'.$log->subject->id : '';
             })
             ->editColumn('created_at', function($log) {
-                return $log->created_at->format('d M Y h:i A');
+                return $log->created_at->format('d-m-Y h:i A');
             })
             ->addColumn('action', function($log) {
                 return '<a href="'.route('admin.activity-logs.show', $log->id).'" class="btn btn-soft-primary btn-sm">

--- a/resources/views/activity-logs/index.blade.php
+++ b/resources/views/activity-logs/index.blade.php
@@ -89,9 +89,9 @@
                         <div class="col-md-4">
                             <label class="form-label">Date Range</label>
                             <div class="input-group">
-                                <input type="date" id="date_from" class="form-control">
+                                <input type="text" id="date_from" class="form-control" placeholder="dd-mm-yyyy">
                                 <span class="input-group-text">to</span>
-                                <input type="date" id="date_to" class="form-control">
+                                <input type="text" id="date_to" class="form-control" placeholder="dd-mm-yyyy">
                             </div>
                         </div>
                         <div class="col-md-4">
@@ -132,6 +132,8 @@
 <script src="https://cdn.datatables.net/1.13.5/js/dataTables.bootstrap5.min.js"></script>
 <script>
 $(function () {
+    flatpickr('#date_from', {dateFormat: 'd-m-Y'});
+    flatpickr('#date_to', {dateFormat: 'd-m-Y'});
     const table = $('#activities-table').DataTable({
         processing: true,
         serverSide: true,

--- a/resources/views/activity-logs/show.blade.php
+++ b/resources/views/activity-logs/show.blade.php
@@ -36,7 +36,7 @@
                         </tr>
                         <tr>
                             <th style="width:30%;">Date/Time</th>
-                            <td>{{ $activity->created_at->format('d M Y H:i:s') }}</td>
+                            <td>{{ $activity->created_at->format('d-m-Y H:i:s') }}</td>
                         </tr>
                     </table>
                 </div>

--- a/resources/views/admin/buyers/_buyers_table.blade.php
+++ b/resources/views/admin/buyers/_buyers_table.blade.php
@@ -36,7 +36,7 @@
                     <input type="checkbox" class="form-check-input profile-verified-toggle" data-id="{{ $buyer->id }}" {{ $buyer->is_profile_verified == 1 ? 'checked' : '' }}>
                 </div>
             </td>
-            <td>{{ \Carbon\Carbon::parse($buyer->created_at)->format('d M Y') }}</td>
+            <td>{{ \Carbon\Carbon::parse($buyer->created_at)->format('d-m-Y') }}</td>
             <td>
                 <div class="d-flex gap-2">
                     <a href="{{ route('admin.buyers.show', $buyer->id) }}" class="btn btn-sm btn-soft-info" title="View">

--- a/resources/views/admin/buyers/edit.blade.php
+++ b/resources/views/admin/buyers/edit.blade.php
@@ -43,7 +43,7 @@
     </style>
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">Edit Buyer</h4>

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -37,7 +37,7 @@
     </style>
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">Add New Category</h4>

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -19,7 +19,7 @@
     </style>
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">Edit Category</h4>

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -407,6 +407,14 @@
                         </a>
                     </li>
 
+                    <!-- Buyers Menu (single item) -->
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.buyers.index') }}">
+                            <span class="nav-icon"><i class="bi bi-people"></i></span>
+                            <span class="nav-text"> Buyers </span>
+                        </a>
+                    </li>
+
                     <!-- Subscriptions Menu (with sub-menu) -->
                     <li class="nav-item">
                         <a class="nav-link menu-arrow" href="#sidebarSubscriptions" data-bs-toggle="collapse"
@@ -431,14 +439,6 @@
                         <a class="nav-link" href="{{ route('admin.plans.index') }}">
                             <span class="nav-icon"><i class="bi bi-card-list"></i></span>
                             <span class="nav-text"> Plans </span>
-                        </a>
-                    </li>
-
-                    <!-- Buyers Menu (single item) -->
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ route('admin.buyers.index') }}">
-                            <span class="nav-icon"><i class="bi bi-people"></i></span>
-                            <span class="nav-text"> Buyers </span>
                         </a>
                     </li>
 

--- a/resources/views/admin/products/_approved_products_table.blade.php
+++ b/resources/views/admin/products/_approved_products_table.blade.php
@@ -7,7 +7,7 @@
             <td>{{ $product->category->name ?? 'N/A' }}</td>
             <td>₹{{ number_format($product->price, 2) }}</td>
             <td>{{ $product->stock_quantity }}</td>
-            <td>{{ $product->updated_at->format('d M Y') }}</td> {{-- Assuming approved_at is updated_at --}}
+            <td>{{ $product->updated_at->format('d-m-Y') }}</td> {{-- Assuming approved_at is updated_at --}}
             <td>
                 <div class="d-flex gap-2">
                     <a href="{{ route('admin.products.approved.show', $product->id) }}" class="btn btn-sm btn-soft-info">

--- a/resources/views/admin/products/_pending_products_table.blade.php
+++ b/resources/views/admin/products/_pending_products_table.blade.php
@@ -7,7 +7,7 @@
             <td>{{ $product->category->name ?? 'N/A' }}</td>
             <td>₹{{ number_format($product->price, 2) }}</td>
             <td>{{ $product->stock_quantity }}</td>
-            <td>{{ $product->updated_at->format('d M Y') }}</td> {{-- Assuming approved_at is updated_at --}}
+            <td>{{ $product->updated_at->format('d-m-Y') }}</td> {{-- Assuming approved_at is updated_at --}}
             <td>
                 <div class="d-flex gap-2">
                     <a href="{{ route('admin.products.approved.show', $product->id) }}" class="btn btn-sm btn-soft-info">

--- a/resources/views/admin/products/_rejected_products_table.blade.php
+++ b/resources/views/admin/products/_rejected_products_table.blade.php
@@ -7,7 +7,7 @@
             <td>{{ $product->category->name ?? 'N/A' }}</td>
             <td>₹{{ number_format($product->price, 2) }}</td>
             <td>{{ $product->stock_quantity }}</td>
-            <td>{{ $product->updated_at->format('d M Y') }}</td> {{-- Assuming approved_at is updated_at --}}
+            <td>{{ $product->updated_at->format('d-m-Y') }}</td> {{-- Assuming approved_at is updated_at --}}
             <td>
                 <div class="d-flex gap-2">
                     <a href="{{ route('admin.products.approved.show', $product->id) }}" class="btn btn-sm btn-soft-info">

--- a/resources/views/admin/vendors/_vendors_table.blade.php
+++ b/resources/views/admin/vendors/_vendors_table.blade.php
@@ -48,7 +48,7 @@
                         {{ $vendor->is_profile_verified == 1 ? 'checked' : '' }}>
                 </div>
             </td>
-            <td>{{ \Carbon\Carbon::parse($vendor->created_at)->format('d M Y') }}</td>
+            <td>{{ \Carbon\Carbon::parse($vendor->created_at)->format('d-m-Y') }}</td>
             <td>
                 <div class="d-flex gap-2">
                     <a href="{{ route('admin.vendors.show', $vendor->id) }}" class="btn btn-sm btn-soft-info"

--- a/resources/views/admin/vendors/edit.blade.php
+++ b/resources/views/admin/vendors/edit.blade.php
@@ -43,7 +43,7 @@
     </style>
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">Edit Vendor</h4>


### PR DESCRIPTION
## Summary
- reorder admin sidebar menu placing Buyers before Subscriptions
- switch multiple templates to `col-md-12` layout
- use dd-mm-yyyy format in activity logs and tables
- parse new date format in `ActivityLogController`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853abd663f48327a5ab30a993cbf2d8