### PR TITLE
Add view/print for vendor subscriptions

### DIFF
--- a/app/Http/Controllers/Admin/VendorSubscriptionController.php
+++ b/app/Http/Controllers/Admin/VendorSubscriptionController.php
@@ -137,4 +137,13 @@ class VendorSubscriptionController extends Controller
         return redirect()->route('admin.vendor-subscriptions.index')
             ->with('success', 'Subscription updated successfully!');
     }
+
+    public function show($id)
+    {
+        $subscription = VendorSubscription::with('user')->findOrFail($id);
+
+        $autoPrint = request()->routeIs('admin.vendor-subscriptions.print');
+
+        return view('admin.subscriptions.show', compact('subscription', 'autoPrint'));
+    }
 }

--- a/resources/views/admin/subscriptions/index.blade.php
+++ b/resources/views/admin/subscriptions/index.blade.php
@@ -37,7 +37,13 @@
                                     </span>
                                 </td>
                                 <td>
-                                    <a href="{{ route('admin.vendor-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm">
+                                    <a href="{{ route('admin.vendor-subscriptions.show', $subscription->id) }}" class="btn btn-secondary btn-sm" title="View">
+                                        <i class="bi bi-eye"></i>
+                                    </a>
+                                    <a href="{{ route('admin.vendor-subscriptions.print', $subscription->id) }}" class="btn btn-info btn-sm" title="Print" target="_blank">
+                                        <i class="bi bi-printer"></i>
+                                    </a>
+                                    <a href="{{ route('admin.vendor-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm" title="Edit">
                                         <i class="bi bi-pencil"></i>
                                     </a>
                                 </td>

--- a/resources/views/admin/subscriptions/show.blade.php
+++ b/resources/views/admin/subscriptions/show.blade.php
@@ -1,0 +1,45 @@
+@extends('admin.layouts.app')
+@section('title', 'Subscription Details | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h4 class="card-title mb-0">Subscription Details</h4>
+                <button onclick="window.print()" class="btn btn-primary btn-sm">
+                    <i class="bi bi-printer"></i> Print
+                </button>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-borderless">
+                        <tr>
+                            <th>Vendor</th>
+                            <td>{{ $subscription->user->name }}</td>
+                        </tr>
+                        <tr>
+                            <th>Plan</th>
+                            <td>{{ $subscription->plan_name }}</td>
+                        </tr>
+                        <tr>
+                            <th>Start Date</th>
+                            <td>{{ \Carbon\Carbon::parse($subscription->start_date)->format('d-m-Y') }}</td>
+                        </tr>
+                        <tr>
+                            <th>End Date</th>
+                            <td>{{ \Carbon\Carbon::parse($subscription->end_date)->format('d-m-Y') }}</td>
+                        </tr>
+                        <tr>
+                            <th>Status</th>
+                            <td>{{ ucfirst($subscription->status) }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@if($autoPrint)
+    <script>window.print();</script>
+@endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,8 @@ Route::middleware(['auth'])->group(function () {
         Route::post('store', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'store'])->name('store');
         Route::get('{id}/edit', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'edit'])->name('edit');
         Route::put('{id}', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'update'])->name('update');
+        Route::get('{id}', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'show'])->name('show');
+        Route::get('{id}/print', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'show'])->name('print');
     });
 
     Route::prefix('admin/buyer-subscriptions')->name('admin.buyer-subscriptions.')->group(function () {


### PR DESCRIPTION
## Summary
- add show route and controller method for vendor subscriptions
- expose print route using the same show view
- create subscription detail view with print button
- show view and print buttons in vendor subscription list

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853c0de9fd8832783a0964623e422f4