### PR TITLE
Implement AJAX vendor subscription list

### DIFF
--- a/resources/views/admin/subscriptions/_subscriptions_table.blade.php
+++ b/resources/views/admin/subscriptions/_subscriptions_table.blade.php
@@ -1,0 +1,37 @@
+{{-- Partial view for vendor subscriptions table --}}
+<tbody>
+    @forelse($subscriptions as $subscription)
+        <tr>
+            <td>{{ ($subscriptions->currentPage() - 1) * $subscriptions->perPage() + $loop->iteration }}</td>
+            <td>{{ $subscription->user->name }}</td>
+            <td>{{ $subscription->plan_name }}</td>
+            <td>{{ \Carbon\Carbon::parse($subscription->start_date)->format('d-m-Y') }}</td>
+            <td>{{ \Carbon\Carbon::parse($subscription->end_date)->format('d-m-Y') }}</td>
+            <td>
+                <span class="badge {{ $subscription->status == 'active' ? 'bg-success' : 'bg-danger' }}">
+                    {{ ucfirst($subscription->status) }}
+                </span>
+            </td>
+            <td>
+                <a href="{{ route('admin.vendor-subscriptions.show', $subscription->id) }}" class="btn btn-secondary btn-sm" title="View">
+                    <iconify-icon icon="solar:eye-broken" class="align-middle fs-18"></iconify-icon>
+                </a>
+                <a href="{{ route('admin.vendor-subscriptions.print', $subscription->id) }}" class="btn btn-info btn-sm" title="Print" target="_blank">
+                    <iconify-icon icon="solar:printer-broken" class="align-middle fs-18"></iconify-icon>
+                </a>
+                <a href="{{ route('admin.vendor-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm" title="Edit">
+                    <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="7" class="text-center">No subscriptions found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$subscriptions" />
+    </tr>
+</tfoot>

--- a/resources/views/admin/subscriptions/index.blade.php
+++ b/resources/views/admin/subscriptions/index.blade.php
@@ -10,54 +10,133 @@
                     <i class="bi bi-plus"></i> Add Subscription
                 </a>
             </div>
-            <div class="card-body table-responsive">
-                <table class="table table-striped">
-                    <thead class="bg-light-subtle">
-                        <tr>
-                            <th>#</th>
-                            <th>Vendor</th>
-                            <th>Plan</th>
-                            <th>Start</th>
-                            <th>End</th>
-                            <th>Status</th>
-                            <th>Action</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @forelse($subscriptions as $subscription)
+            <div class="card-body">
+                <form id="filter-form" class="row g-2 align-items-end mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label" for="vendor">Vendor Name</label>
+                        <input type="text" id="vendor" class="form-control" placeholder="Vendor Name">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label" for="plan">Plan Name</label>
+                        <select id="plan" class="form-select">
+                            <option value="">All Plans</option>
+                            @foreach($plans as $plan)
+                                <option value="{{ $plan }}">{{ $plan }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label" for="status">Status</label>
+                        <select id="status" class="form-select">
+                            <option value="">All</option>
+                            <option value="active">Active</option>
+                            <option value="expired">Expired</option>
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <button type="button" id="search" class="btn btn-primary">
+                            <i class="bi bi-search"></i> SEARCH
+                        </button>
+                        <button type="button" id="reset" class="btn btn-outline-danger">
+                            <i class="bi bi-arrow-clockwise"></i> RESET
+                        </button>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table table-striped" id="subscriptions-table" style="width:100%">
+                        <thead class="bg-light-subtle">
                             <tr>
-                                <td>{{ $loop->iteration }}</td>
-                                <td>{{ $subscription->user->name }}</td>
-                                <td>{{ $subscription->plan_name }}</td>
-                                <td>{{ \Carbon\Carbon::parse($subscription->start_date)->format('d-m-Y') }}</td>
-                                <td>{{ \Carbon\Carbon::parse($subscription->end_date)->format('d-m-Y') }}</td>
-                                <td>
-                                    <span class="badge {{ $subscription->status == 'active' ? 'bg-success' : 'bg-danger' }}">
-                                        {{ ucfirst($subscription->status) }}
-                                    </span>
-                                </td>
-                                <td>
-                                    <a href="{{ route('admin.vendor-subscriptions.show', $subscription->id) }}" class="btn btn-secondary btn-sm" title="View">
-                                        <iconify-icon icon="solar:eye-broken" class="align-middle fs-18"></iconify-icon>
-                                    </a>
-                                    <a href="{{ route('admin.vendor-subscriptions.print', $subscription->id) }}" class="btn btn-info btn-sm" title="Print" target="_blank">
-                                        <iconify-icon icon="solar:printer-broken" class="align-middle fs-18"></iconify-icon>
-                                    </a>
-                                    <a href="{{ route('admin.vendor-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm" title="Edit">
-                                        <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
-                                    </a>
-                                </td>
+                                <th>#</th>
+                                <th>Vendor</th>
+                                <th>Plan</th>
+                                <th>Start</th>
+                                <th>End</th>
+                                <th>Status</th>
+                                <th>Action</th>
                             </tr>
-                        @empty
+                        </thead>
+                        <tbody id="subscriptions-table-body-content">
                             <tr>
-                                <td colspan="7" class="text-center">No subscriptions found.</td>
+                                <td colspan="7" class="text-center">Loading Subscriptions...</td>
                             </tr>
-                        @endforelse
-                    </tbody>
-                </table>
-                {{ $subscriptions->links() }}
+                        </tbody>
+                        <tfoot id="subscriptions-table-foot-content">
+                            <tr>
+                                <td colspan="7" class="text-center"></td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
 </div>
+<script>
+$(document).ready(function() {
+    fetchSubscriptionsData(1);
+
+    var currentAjaxRequest = null;
+
+    function fetchSubscriptionsData(page = 1, perPage = null) {
+        if (currentAjaxRequest && currentAjaxRequest.readyState !== 4) {
+            currentAjaxRequest.abort();
+        }
+        $('#subscriptions-table-body-content').html('<tr><td colspan="7" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+        $('#subscriptions-table-foot-content').empty();
+
+        const filters = {
+            vendor: $('#vendor').val(),
+            plan: $('#plan').val(),
+            status: $('#status').val()
+        };
+        perPage = perPage || $('#perPage').val() || 10;
+
+        currentAjaxRequest = $.ajax({
+            url: "{{ route('admin.vendor-subscriptions.render-table') }}",
+            method: 'GET',
+            data: {
+                page: page,
+                per_page: perPage,
+                ...filters
+            },
+            success: function(response) {
+                const $responseHtml = $(response);
+                $('#subscriptions-table-body-content').html($responseHtml.filter('tbody').html());
+                $('#subscriptions-table-foot-content').html($responseHtml.filter('tfoot').html());
+            },
+            error: function(xhr) {
+                if (xhr.statusText === 'abort') {
+                    return;
+                }
+                $('#subscriptions-table-body-content').html('<tr><td colspan="7" class="text-center text-danger">Error loading subscriptions.</td></tr>');
+            },
+            complete: function() {
+                currentAjaxRequest = null;
+            }
+        });
+    }
+
+    $('#search').on('click', function() {
+        fetchSubscriptionsData(1);
+    });
+
+    $('#reset').on('click', function() {
+        $('#filter-form').find('input, select').val('');
+        fetchSubscriptionsData(1);
+    });
+
+    $(document).on('click', '#subscriptions-table-foot-content a.page-link', function(e) {
+        e.preventDefault();
+        const url = $(this).attr('href');
+        const page = new URL(url).searchParams.get('page');
+        if (page) {
+            fetchSubscriptionsData(page);
+        }
+    });
+
+    $(document).on('change', '#perPage', function() {
+        fetchSubscriptionsData(1, $(this).val());
+    });
+});
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,7 @@ Route::middleware(['auth'])->group(function () {
 
     Route::prefix('admin/vendor-subscriptions')->name('admin.vendor-subscriptions.')->group(function () {
         Route::get('/', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'index'])->name('index');
+        Route::get('render-table', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'renderSubscriptionsTable'])->name('render-table');
         Route::get('create', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'create'])->name('create');
         Route::post('store', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'store'])->name('store');
         Route::get('{id}/edit', [App\Http\Controllers\Admin\VendorSubscriptionController::class, 'edit'])->name('edit');


### PR DESCRIPTION
## Summary
- load vendor subscription list via AJAX similar to vendor list
- add filter form for vendor, plan and status
- show results using new `_subscriptions_table` partial
- add controller method and route for AJAX table rendering

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c4328a2483278e8c0ddb440dfad4