### PR TITLE
Add AJAX buyer subscriptions list with print view

### DIFF
--- a/resources/views/admin/buyer_subscriptions/_subscriptions_table.blade.php
+++ b/resources/views/admin/buyer_subscriptions/_subscriptions_table.blade.php
@@ -1,0 +1,37 @@
+{{-- Partial view for buyer subscriptions table --}}
+<tbody>
+    @forelse($subscriptions as $subscription)
+        <tr>
+            <td>{{ ($subscriptions->currentPage() - 1) * $subscriptions->perPage() + $loop->iteration }}</td>
+            <td>{{ $subscription->user->name }}</td>
+            <td>{{ $subscription->plan_name }}</td>
+            <td>{{ \Carbon\Carbon::parse($subscription->start_date)->format('d-m-Y') }}</td>
+            <td>{{ \Carbon\Carbon::parse($subscription->end_date)->format('d-m-Y') }}</td>
+            <td>
+                <span class="badge {{ $subscription->status == 'active' ? 'bg-success' : 'bg-danger' }}">
+                    {{ ucfirst($subscription->status) }}
+                </span>
+            </td>
+            <td>
+                <a href="{{ route('admin.buyer-subscriptions.show', $subscription->id) }}" class="btn btn-secondary btn-sm" title="View">
+                    <iconify-icon icon="solar:eye-broken" class="align-middle fs-18"></iconify-icon>
+                </a>
+                <a href="{{ route('admin.buyer-subscriptions.print', $subscription->id) }}" class="btn btn-info btn-sm" title="Print" target="_blank">
+                    <iconify-icon icon="solar:printer-broken" class="align-middle fs-18"></iconify-icon>
+                </a>
+                <a href="{{ route('admin.buyer-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm" title="Edit">
+                    <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="7" class="text-center">No subscriptions found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$subscriptions" />
+    </tr>
+</tfoot>

--- a/resources/views/admin/buyer_subscriptions/index.blade.php
+++ b/resources/views/admin/buyer_subscriptions/index.blade.php
@@ -2,7 +2,7 @@
 @section('title', 'Buyer Subscriptions | Deal24hours')
 @section('content')
 <div class="row">
-    <div class="col-xl-12">
+    <div class="col-md-12">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center gap-1">
                 <h4 class="card-title flex-grow-1 mb-0">Buyer Subscriptions</h4>
@@ -10,48 +10,133 @@
                     <i class="bi bi-plus"></i> Add Subscription
                 </a>
             </div>
-            <div class="card-body table-responsive">
-                <table class="table table-striped">
-                    <thead class="bg-light-subtle">
-                        <tr>
-                            <th>#</th>
-                            <th>Buyer</th>
-                            <th>Plan</th>
-                            <th>Start</th>
-                            <th>End</th>
-                            <th>Status</th>
-                            <th>Action</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @forelse($subscriptions as $subscription)
+            <div class="card-body">
+                <form id="filter-form" class="row g-2 align-items-end mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label" for="buyer">Buyer Name</label>
+                        <input type="text" id="buyer" class="form-control" placeholder="Buyer Name">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label" for="plan">Plan Name</label>
+                        <select id="plan" class="form-select">
+                            <option value="">All Plans</option>
+                            @foreach($plans as $plan)
+                                <option value="{{ $plan }}">{{ $plan }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label" for="status">Status</label>
+                        <select id="status" class="form-select">
+                            <option value="">All</option>
+                            <option value="active">Active</option>
+                            <option value="expired">Expired</option>
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <button type="button" id="search" class="btn btn-primary">
+                            <i class="bi bi-search"></i> SEARCH
+                        </button>
+                        <button type="button" id="reset" class="btn btn-outline-danger">
+                            <i class="bi bi-arrow-clockwise"></i> RESET
+                        </button>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table table-striped" id="subscriptions-table" style="width:100%">
+                        <thead class="bg-light-subtle">
                             <tr>
-                                <td>{{ $loop->iteration }}</td>
-                                <td>{{ $subscription->user->name }}</td>
-                                <td>{{ $subscription->plan_name }}</td>
-                                <td>{{ \Carbon\Carbon::parse($subscription->start_date)->format('d-m-Y') }}</td>
-                                <td>{{ \Carbon\Carbon::parse($subscription->end_date)->format('d-m-Y') }}</td>
-                                <td>
-                                    <span class="badge {{ $subscription->status == 'active' ? 'bg-success' : 'bg-danger' }}">
-                                        {{ ucfirst($subscription->status) }}
-                                    </span>
-                                </td>
-                                <td>
-                                    <a href="{{ route('admin.buyer-subscriptions.edit', $subscription->id) }}" class="btn btn-soft-primary btn-sm">
-                                        <i class="bi bi-pencil"></i>
-                                    </a>
-                                </td>
+                                <th>#</th>
+                                <th>Buyer</th>
+                                <th>Plan</th>
+                                <th>Start</th>
+                                <th>End</th>
+                                <th>Status</th>
+                                <th>Action</th>
                             </tr>
-                        @empty
+                        </thead>
+                        <tbody id="subscriptions-table-body-content">
                             <tr>
-                                <td colspan="7" class="text-center">No subscriptions found.</td>
+                                <td colspan="7" class="text-center">Loading Subscriptions...</td>
                             </tr>
-                        @endforelse
-                    </tbody>
-                </table>
-                {{ $subscriptions->links() }}
+                        </tbody>
+                        <tfoot id="subscriptions-table-foot-content">
+                            <tr>
+                                <td colspan="7" class="text-center"></td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
 </div>
+<script>
+$(document).ready(function() {
+    fetchSubscriptionsData(1);
+
+    var currentAjaxRequest = null;
+
+    function fetchSubscriptionsData(page = 1, perPage = null) {
+        if (currentAjaxRequest && currentAjaxRequest.readyState !== 4) {
+            currentAjaxRequest.abort();
+        }
+        $('#subscriptions-table-body-content').html('<tr><td colspan="7" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+        $('#subscriptions-table-foot-content').empty();
+
+        const filters = {
+            buyer: $('#buyer').val(),
+            plan: $('#plan').val(),
+            status: $('#status').val()
+        };
+        perPage = perPage || $('#perPage').val() || 10;
+
+        currentAjaxRequest = $.ajax({
+            url: "{{ route('admin.buyer-subscriptions.render-table') }}",
+            method: 'GET',
+            data: {
+                page: page,
+                per_page: perPage,
+                ...filters
+            },
+            success: function(response) {
+                const $responseHtml = $(response);
+                $('#subscriptions-table-body-content').html($responseHtml.filter('tbody').html());
+                $('#subscriptions-table-foot-content').html($responseHtml.filter('tfoot').html());
+            },
+            error: function(xhr) {
+                if (xhr.statusText === 'abort') {
+                    return;
+                }
+                $('#subscriptions-table-body-content').html('<tr><td colspan="7" class="text-center text-danger">Error loading subscriptions.</td></tr>');
+            },
+            complete: function() {
+                currentAjaxRequest = null;
+            }
+        });
+    }
+
+    $('#search').on('click', function() {
+        fetchSubscriptionsData(1);
+    });
+
+    $('#reset').on('click', function() {
+        $('#filter-form').find('input, select').val('');
+        fetchSubscriptionsData(1);
+    });
+
+    $(document).on('click', '#subscriptions-table-foot-content a.page-link', function(e) {
+        e.preventDefault();
+        const url = $(this).attr('href');
+        const page = new URL(url).searchParams.get('page');
+        if (page) {
+            fetchSubscriptionsData(page);
+        }
+    });
+
+    $(document).on('change', '#perPage', function() {
+        fetchSubscriptionsData(1, $(this).val());
+    });
+});
+</script>
 @endsection

--- a/resources/views/admin/buyer_subscriptions/show.blade.php
+++ b/resources/views/admin/buyer_subscriptions/show.blade.php
@@ -1,0 +1,45 @@
+@extends('admin.layouts.app')
+@section('title', 'Subscription Details | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h4 class="card-title mb-0">Subscription Details</h4>
+                <button onclick="window.print()" class="btn btn-primary btn-sm">
+                    <i class="bi bi-printer"></i> Print
+                </button>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-borderless">
+                        <tr>
+                            <th>Buyer</th>
+                            <td>{{ $subscription->user->name }}</td>
+                        </tr>
+                        <tr>
+                            <th>Plan</th>
+                            <td>{{ $subscription->plan_name }}</td>
+                        </tr>
+                        <tr>
+                            <th>Start Date</th>
+                            <td>{{ \Carbon\Carbon::parse($subscription->start_date)->format('d-m-Y') }}</td>
+                        </tr>
+                        <tr>
+                            <th>End Date</th>
+                            <td>{{ \Carbon\Carbon::parse($subscription->end_date)->format('d-m-Y') }}</td>
+                        </tr>
+                        <tr>
+                            <th>Status</th>
+                            <td>{{ ucfirst($subscription->status) }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@if($autoPrint)
+    <script>window.print();</script>
+@endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,10 +94,13 @@ Route::middleware(['auth'])->group(function () {
 
     Route::prefix('admin/buyer-subscriptions')->name('admin.buyer-subscriptions.')->group(function () {
         Route::get('/', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'index'])->name('index');
+        Route::get('render-table', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'renderSubscriptionsTable'])->name('render-table');
         Route::get('create', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'create'])->name('create');
         Route::post('store', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'store'])->name('store');
         Route::get('{id}/edit', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'edit'])->name('edit');
         Route::put('{id}', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'update'])->name('update');
+        Route::get('{id}', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'show'])->name('show');
+        Route::get('{id}/print', [App\Http\Controllers\Admin\BuyerSubscriptionController::class, 'show'])->name('print');
     });
 
     Route::prefix('admin/plans')->name('admin.plans.')->group(function () {


### PR DESCRIPTION
## Summary
- implement AJAX list for buyer subscriptions with filters
- add show and print options for buyer subscriptions
- include routes and views similar to vendor subscriptions

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853cae243a0832781ea1a6b6f283bee