### PR TITLE
Add admin products list

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Product;
+
+class ProductController extends Controller
+{
+    public function index()
+    {
+        return view('admin.products.all');
+    }
+
+    public function renderProductsTable(Request $request)
+    {
+        $perPage = $request->input('per_page', 10);
+        $page = $request->input('page', 1);
+
+        $productsQuery = Product::with(['vendor', 'category']);
+
+        if ($request->product_name) {
+            $productsQuery->whereRaw('MATCH(product_name) AGAINST(? IN BOOLEAN MODE)', [$request->product_name]);
+        }
+
+        $productsQuery->when($request->vendor_id, function ($query, $vendorId) {
+            $query->where('vendor_id', $vendorId);
+        });
+
+        $productsQuery->when($request->status !== null && $request->status !== '', function ($query) use ($request) {
+            $query->where('status', $request->status);
+        });
+
+        $productsQuery->orderBy('created_at', 'desc');
+
+        $products = $productsQuery->paginate($perPage, ['*'], 'page', $page);
+
+        return view('admin.products._all_products_table', compact('products'));
+    }
+}

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -375,6 +375,13 @@
                             <ul class="nav sub-navbar-nav">
 
                                 <li class="sub-nav-item">
+                                    <a class="sub-nav-link" href="{{ route('admin.products.all') }}">
+                                        <span class="nav-text"> Products</span>&nbsp;&nbsp;
+                                        <span class="badge bg-secondary-subtle text-secondary py-1 px-2">All</span>
+                                    </a>
+                                </li>
+
+                                <li class="sub-nav-item">
                                     <a class="sub-nav-link" href="{{ route('admin.products.approved') }}">
                                         <span class="nav-text"> Products</span>&nbsp;&nbsp;
                                         <span class="badge bg-success-subtle text-success py-1 px-2">Approved</span>

--- a/resources/views/admin/products/_all_products_table.blade.php
+++ b/resources/views/admin/products/_all_products_table.blade.php
@@ -1,0 +1,37 @@
+<tbody>
+    @forelse($products as $product)
+        <tr>
+            <td>{{ $loop->iteration + ($products->currentPage() - 1) * $products->perPage() }}</td>
+            <td>{{ $product->product_name }}</td>
+            <td>{{ $product->vendor->name ?? 'N/A' }}</td>
+            <td>{{ $product->category->name ?? 'N/A' }}</td>
+            <td>₹{{ number_format($product->price, 2) }}</td>
+            <td>{{ $product->stock_quantity }}</td>
+            <td>
+                @php
+                    $statusClass = [
+                        'approved' => 'success',
+                        'pending' => 'warning',
+                        'rejected' => 'danger',
+                    ][$product->status] ?? 'secondary';
+                @endphp
+                <span class="badge bg-{{ $statusClass }}">{{ ucfirst($product->status) }}</span>
+            </td>
+            <td>{{ $product->updated_at->format('d-m-Y') }}</td>
+            <td>
+                <a href="{{ route('admin.products.approved.show', $product->id) }}" class="btn btn-sm btn-soft-info">
+                    <i class="bi bi-eye"></i>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="9" class="text-center">No products found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$products" />
+    </tr>
+</tfoot>

--- a/resources/views/admin/products/all.blade.php
+++ b/resources/views/admin/products/all.blade.php
@@ -1,0 +1,153 @@
+@extends('admin.layouts.app')
+@section('title', 'All Products | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">All Products</h4>
+            </div>
+            <div>
+                <div class="card-body">
+                    <form id="filter-form" class="row g-2 align-items-end">
+                        <div class="col-md-3">
+                            <label class="form-label">Product Name</label>
+                            <div class="input-group">
+                                <span class="input-group-text"><i class="bi bi-box-seam"></i></span>
+                                <input type="text" id="product_name" class="form-control" placeholder="Product Name">
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Vendor</label>
+                            <div class="input-group select2-group">
+                                <span class="input-group-text"><i class="bi bi-person"></i></span>
+                                <select id="vendor_id" class="form-select select2" style="width: 100%;">
+                                    <option value="">Search vendor</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Status</label>
+                            <div class="input-group">
+                                <span class="input-group-text"><i class="bi bi-check2-circle"></i></span>
+                                <select id="status" class="form-select">
+                                    <option value="">All</option>
+                                    <option value="approved">Approved</option>
+                                    <option value="pending">Pending</option>
+                                    <option value="rejected">Rejected</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <button type="button" id="search" class="btn btn-primary">
+                                <i class="bi bi-search"></i> SEARCH
+                            </button>
+                            <button type="button" id="reset" class="btn btn-outline-danger">
+                                <i class="bi bi-arrow-clockwise"></i> RESET
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                <div class="table-responsive px-4 mb-3">
+                    <table class="table align-middle mb-0 table-striped table-centered" id="products-table" style="width: 100%;">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>#</th>
+                                <th>Product Name</th>
+                                <th>Vendor</th>
+                                <th>Category</th>
+                                <th>Price</th>
+                                <th>Stock</th>
+                                <th>Status</th>
+                                <th>Updated On</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody id="products-table-body-content">
+                            <tr>
+                                <td colspan="9" class="text-center">Loading Products...</td>
+                            </tr>
+                        </tbody>
+                        <tfoot id="products-table-foot-content">
+                            <tr>
+                                <td colspan="9" class="text-center"></td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script>
+$(document).ready(function(){
+    fetchProductsData(1);
+    var currentAjaxRequest = null;
+
+    function fetchProductsData(page = 1, perPage = null){
+        if(currentAjaxRequest && currentAjaxRequest.readyState !== 4){
+            currentAjaxRequest.abort();
+        }
+        $('#products-table-body-content').html('<tr><td colspan="9" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+        $('#products-table-foot-content').empty();
+
+        const filters = {
+            product_name: $('#product_name').val(),
+            vendor_id: $('#vendor_id').val(),
+            status: $('#status').val()
+        };
+        perPage = perPage || $('#perPage').val() || 10;
+
+        currentAjaxRequest = $.ajax({
+            url: "{{ route('admin.products.all.render-table') }}",
+            method: 'GET',
+            data: {
+                page: page,
+                per_page: perPage,
+                ...filters
+            },
+            success: function(response){
+                const $responseHtml = $(response);
+                $('#products-table-body-content').html($responseHtml.filter('tbody').html());
+                $('#products-table-foot-content').html($responseHtml.filter('tfoot').html());
+            },
+            error: function(xhr){
+                if(xhr.statusText === 'abort'){ return; }
+                $('#products-table-body-content').html('<tr><td colspan="9" class="text-center text-danger">Error loading products.</td></tr>');
+            },
+            complete: function(){ currentAjaxRequest = null; }
+        });
+    }
+
+    $('#search').on('click', function(){ fetchProductsData(1); });
+    $('#reset').on('click', function(){
+        $('#filter-form').find('input, select').val('').trigger('change');
+        fetchProductsData(1);
+    });
+    $(document).on('click', '#products-table-foot-content a.page-link', function(e){
+        e.preventDefault();
+        const url = $(this).attr('href');
+        const page = new URL(url).searchParams.get('page');
+        if(page){ fetchProductsData(page); }
+    });
+    $(document).on('change', '#perPage', function(){ fetchProductsData(1, $(this).val()); });
+
+    $('#vendor_id').select2({
+        placeholder: 'Search vendor',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('admin.vendors.search') }}",
+            dataType: 'json',
+            delay: 250,
+            data: function(params){ return { q: params.term }; },
+            processResults: function(data){
+                return { results: data.map(function(v){ return { id: v.id, text: v.name }; }) };
+            },
+            cache: true
+        }
+    });
+});
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Admin\PendingProductController;
 use App\Http\Controllers\Admin\ApprovedProductController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\RejectedProductController;
+use App\Http\Controllers\Admin\ProductController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Vendor\VendorDashboardController;
 use App\Http\Controllers\Vendor\VendorProfileController;
@@ -163,6 +164,10 @@ Route::middleware(['auth'])->group(function () {
         Route::get('rejected/render-table', [RejectedProductController::class, 'renderRejectedProductsTable'])->name('admin.rejected.products.render-table');
         Route::get('/rejected/{id}', [RejectedProductController::class, 'show'])->name('admin.products.rejected.show');
     Route::post('/rejected/{id}/restore', [RejectedProductController::class, 'restore'])->name('admin.products.rejected.restore');
+
+        // List all products with AJAX pagination similar to vendors
+        Route::get('/all', [ProductController::class, 'index'])->name('admin.products.all');
+        Route::get('/all/render-table', [ProductController::class, 'renderProductsTable'])->name('admin.products.all.render-table');
     });
 
     Route::get('/vendor/dashboard', [VendorDashboardController::class, 'index'])->name('vendor.dashboard');


### PR DESCRIPTION
## Summary
- show all products with new Admin\ProductController
- add new route and sidebar link for list
- render AJAX-powered table in `products/all`
- display product statuses and dates in dd-mm-yyyy

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853dc2a91548327ba3555dff7822372