### PR TITLE
Add dashboard menu to vendor sidebar

### DIFF
--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -296,6 +296,12 @@
         <div class="scrollbar" data-simplebar>
             <ul class="navbar-nav" id="navbar-nav">
                 <li class="menu-title">General</li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ route('vendor.dashboard') }}">
+                        <span class="nav-icon"><i class="bi bi-speedometer2"></i></span>
+                        <span class="nav-text"> Dashboard </span>
+                    </a>
+                </li>
                 @foreach([
                     ['title' => 'Products', 'icon' => 'bi-box-seam', 'id' => 'sidebarProducts', 'items' => [
                         


### PR DESCRIPTION
## Summary
- add a dashboard link in the vendor layout sidebar

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e513018c83278b2d76c5afaf6b86