### PR TITLE
Add AJAX pagination for vendor products

### DIFF
--- a/app/Http/Controllers/Vendor/VendorProductController.php
+++ b/app/Http/Controllers/Vendor/VendorProductController.php
@@ -78,6 +78,26 @@ class VendorProductController extends Controller
             ->make(true);
     }
 
+    // Render paginated products table for AJAX requests
+    public function renderProductsTable(Request $request)
+    {
+        $perPage = $request->input('per_page', 10);
+
+        $productsQuery = Product::where('vendor_id', Auth::id());
+
+        if ($request->filled('product_name')) {
+            $productsQuery->where('product_name', 'like', '%' . $request->product_name . '%');
+        }
+
+        if ($request->filled('status')) {
+            $productsQuery->where('status', $request->status);
+        }
+
+        $products = $productsQuery->orderBy('created_at', 'desc')->paginate($perPage);
+
+        return view('vendor.products._products_table', compact('products'));
+    }
+
     // Show create product form
     public function create()
     {

--- a/resources/views/vendor/products/_products_table.blade.php
+++ b/resources/views/vendor/products/_products_table.blade.php
@@ -1,0 +1,45 @@
+<tbody>
+    @forelse($products as $product)
+        <tr>
+            <td>{{ $loop->iteration + ($products->currentPage() - 1) * $products->perPage() }}</td>
+            <td>{{ $product->product_name }}</td>
+            <td>₹{{ number_format($product->price, 2) }}</td>
+            <td>{{ $product->stock_quantity }}</td>
+            <td>
+                @php
+                    if ($product->status === 'approved') {
+                        $class = 'badge border border-success text-success px-2 py-1 fs-13';
+                    } elseif ($product->status === 'pending') {
+                        $class = 'badge border border-warning text-warning px-2 py-1 fs-13';
+                    } else {
+                        $class = 'badge border border-danger text-danger px-2 py-1 fs-13';
+                    }
+                @endphp
+                <span class="{{ $class }}">{{ ucfirst($product->status) }}</span>
+            </td>
+            <td>{{ \Carbon\Carbon::parse($product->created_at)->format('d-m-Y') }}</td>
+            <td>
+                <div class="d-flex gap-2">
+                    <a href="{{ route('vendor.products.show', $product->id) }}" class="btn btn-sm btn-soft-info" title="View">
+                        <i class="bi bi-eye"></i>
+                    </a>
+                    <a href="{{ route('vendor.products.edit', $product->id) }}" class="btn btn-sm btn-soft-warning" title="Edit">
+                        <i class="bi bi-pencil"></i>
+                    </a>
+                    <button class="btn btn-sm btn-soft-danger delete-product" data-id="{{ $product->id }}" title="Delete">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="7" class="text-center">No products found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$products" />
+    </tr>
+</tfoot>

--- a/routes/web.php
+++ b/routes/web.php
@@ -176,6 +176,7 @@ Route::middleware(['auth'])->group(function () {
     Route::prefix('vendor/products')->name('vendor.products.')->group(function () {
         Route::get('list', [VendorProductController::class, 'index'])->name('index');
         Route::get('data', [VendorProductController::class, 'getProducts'])->name('data');
+        Route::get('render-table', [VendorProductController::class, 'renderProductsTable'])->name('render-table');
         Route::get('create', [VendorProductController::class, 'create'])->name('create');
         Route::get('get-subcategories/{parentId}', [VendorProductController::class, 'getSubcategories'])->name('get-subcategories');
         Route::post('save', [VendorProductController::class, 'store'])->name('store');


### PR DESCRIPTION
## Summary
- implement server-side renderProductsTable for vendor products
- use Laravel pagination with AJAX filters in vendor product list
- include new `_products_table` partial and update routes

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6853e7b9974c8327b6c155c517b0b190