### PR TITLE
Add vendor product status views

### DIFF
--- a/app/Http/Controllers/Vendor/VendorProductController.php
+++ b/app/Http/Controllers/Vendor/VendorProductController.php
@@ -19,7 +19,36 @@ class VendorProductController extends Controller
     // Show vendor's all products
     public function index()
     {
-        return view('vendor.products.index');
+        return view('vendor.products.index', [
+            'pageTitle' => 'All Product List'
+        ]);
+    }
+
+    // Show approved products list
+    public function approved()
+    {
+        return view('vendor.products.index', [
+            'statusDefault' => 'approved',
+            'pageTitle' => 'Approved Products'
+        ]);
+    }
+
+    // Show pending products list
+    public function pending()
+    {
+        return view('vendor.products.index', [
+            'statusDefault' => 'pending',
+            'pageTitle' => 'Pending Products'
+        ]);
+    }
+
+    // Show rejected products list
+    public function rejected()
+    {
+        return view('vendor.products.index', [
+            'statusDefault' => 'rejected',
+            'pageTitle' => 'Rejected Products'
+        ]);
     }
 
     // Fetch products for DataTable

--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -304,11 +304,11 @@
                 </li>
                 @foreach([
                     ['title' => 'Products', 'icon' => 'bi-box-seam', 'id' => 'sidebarProducts', 'items' => [
-                        
                         ['name' => 'Add Product ', 'route' => 'vendor.products.create'],
-                        ['name' => ' Product List', 'route' => 'vendor.products.index']
-                    
-                        
+                        ['name' => 'Product List', 'route' => 'vendor.products.index'],
+                        ['name' => 'Approved Products', 'route' => 'vendor.products.approved'],
+                        ['name' => 'Pending Products', 'route' => 'vendor.products.pending'],
+                        ['name' => 'Rejected Products', 'route' => 'vendor.products.rejected'],
                     ]]
                   
                 ] as $menu)

--- a/resources/views/vendor/products/index.blade.php
+++ b/resources/views/vendor/products/index.blade.php
@@ -1,5 +1,5 @@
 @extends('vendor.layouts.app')
-@section('title', 'Vendor Profile | Deal24hours')
+@section('title', ($pageTitle ?? 'Product List') . ' | Deal24hours')
 @section('content')
 @push('styles')
 <style>
@@ -13,7 +13,7 @@
      <div class="col-md-12">
           <div class="card">
                <div class="card-header d-flex justify-content-between align-items-center gap-1">
-                    <h4 class="card-title flex-grow-1">All Product List</h4>
+                    <h4 class="card-title flex-grow-1">{{ $pageTitle ?? 'All Product List' }}</h4>
 
                     <a href="{{ route('vendor.products.create') }}" class="btn btn-sm btn-primary">
                          <i class="bi bi-plus-lg" style="font-size: 16px;"></i> Add Product
@@ -85,6 +85,11 @@
 
 <script>
 $(document).ready(function() {
+    var defaultStatus = "{{ $statusDefault ?? '' }}";
+    if(defaultStatus){
+        $('#status').val(defaultStatus);
+    }
+
     fetchProductsData(1);
 
     var currentAjaxRequest = null;

--- a/routes/web.php
+++ b/routes/web.php
@@ -175,6 +175,9 @@ Route::middleware(['auth'])->group(function () {
 
     Route::prefix('vendor/products')->name('vendor.products.')->group(function () {
         Route::get('list', [VendorProductController::class, 'index'])->name('index');
+        Route::get('approved', [VendorProductController::class, 'approved'])->name('approved');
+        Route::get('pending', [VendorProductController::class, 'pending'])->name('pending');
+        Route::get('rejected', [VendorProductController::class, 'rejected'])->name('rejected');
         Route::get('data', [VendorProductController::class, 'getProducts'])->name('data');
         Route::get('render-table', [VendorProductController::class, 'renderProductsTable'])->name('render-table');
         Route::get('create', [VendorProductController::class, 'create'])->name('create');


### PR DESCRIPTION
## Summary
- allow vendors to access pre-filtered approved/pending/rejected product lists
- add corresponding routes and navigation items
- allow product index page to set default status and title

## Testing
- `composer install` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f8a7a2188327ae43c19acd19d521