### PR TITLE
Fix vendor product list filter

### DIFF
--- a/resources/views/vendor/products/index.blade.php
+++ b/resources/views/vendor/products/index.blade.php
@@ -86,8 +86,8 @@
 <script>
 $(document).ready(function() {
     var defaultStatus = "{{ $statusDefault ?? '' }}";
-    if(defaultStatus){
-        $('#status').val(defaultStatus);
+    if (defaultStatus) {
+        $('#status').val(defaultStatus).prop('disabled', true);
     }
 
     fetchProductsData(1);
@@ -141,6 +141,9 @@ $(document).ready(function() {
 
     $('#reset').on('click', function() {
         $('#filter-form').trigger('reset');
+        if (defaultStatus) {
+            $('#status').val(defaultStatus).prop('disabled', true);
+        }
         fetchProductsData(1);
     });
 


### PR DESCRIPTION
## Summary
- disable status filter control when viewing approved/pending/rejected product lists
- keep default status when resetting search filter

## Testing
- `composer install --no-interaction` *(fails: composer not found)*
- `./vendor/bin/phpunit` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542253179c8327a8e6973ae37389f1