### PR TITLE
Add vendor help support module

### DIFF
--- a/app/Http/Controllers/Vendor/VendorHelpSupportController.php
+++ b/app/Http/Controllers/Vendor/VendorHelpSupportController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Storage;
+use App\Models\HelpSupport;
+use Carbon\Carbon;
+
+class VendorHelpSupportController extends Controller
+{
+    public function index()
+    {
+        return view('vendor.help_support.index', [
+            'pageTitle' => 'Help & Support List'
+        ]);
+    }
+
+    public function renderHelpsTable(Request $request)
+    {
+        $query = HelpSupport::where('created_by', Auth::id());
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        if ($request->filled('name')) {
+            $query->where('name', 'like', '%' . $request->name . '%');
+        }
+
+        $helps = $query->orderBy('created_at', 'desc')
+                        ->paginate($request->input('per_page', 10));
+
+        return view('vendor.help_support._table', compact('helps'));
+    }
+
+    public function create()
+    {
+        return view('vendor.help_support.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'contact_no' => 'required|string|max:20',
+            'email' => 'required|email|max:255',
+            'message' => 'required|string',
+            'attachment' => 'nullable|file|mimes:jpg,jpeg,png,pdf,doc,docx|max:2048',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => false,
+                'message' => $validator->errors()->first(),
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+        $data['user_type'] = 'vendor';
+        $data['status'] = 'open';
+        $data['created_by'] = Auth::id();
+        $data['updated_by'] = Auth::id();
+
+        if ($request->hasFile('attachment')) {
+            $path = $request->file('attachment')->store('uploads/help_support', 'public');
+            $data['attachment'] = $path;
+        }
+
+        HelpSupport::create($data);
+
+        return response()->json([
+            'status' => true,
+            'message' => 'Request submitted successfully!',
+            'redirect' => route('vendor.help-support.index'),
+        ]);
+    }
+
+    public function show($id)
+    {
+        $help = HelpSupport::where('id', $id)
+            ->where('created_by', Auth::id())
+            ->firstOrFail();
+
+        return view('vendor.help_support.show', compact('help'));
+    }
+}

--- a/app/Models/HelpSupport.php
+++ b/app/Models/HelpSupport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class HelpSupport extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_type',
+        'name',
+        'contact_no',
+        'email',
+        'message',
+        'attachment',
+        'reply_message',
+        'status',
+        'created_by',
+        'updated_by',
+    ];
+}

--- a/database/migrations/2025_06_18_160000_create_help_supports_table.php
+++ b/database/migrations/2025_06_18_160000_create_help_supports_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('help_supports', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->enum('user_type', ['vendor', 'buyer']);
+            $table->string('name');
+            $table->string('contact_no', 20);
+            $table->string('email');
+            $table->text('message');
+            $table->string('attachment')->nullable();
+            $table->text('reply_message')->nullable();
+            $table->enum('status', ['open', 'pending', 'on_hold', 'solved', 'closed'])->default('open');
+            $table->unsignedBigInteger('created_by');
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('help_supports');
+    }
+};

--- a/resources/views/vendor/help_support/_table.blade.php
+++ b/resources/views/vendor/help_support/_table.blade.php
@@ -1,0 +1,33 @@
+<tbody>
+    @forelse($helps as $help)
+        <tr>
+            <td>{{ $loop->iteration + ($helps->currentPage() - 1) * $helps->perPage() }}</td>
+            <td>{{ $help->name }}</td>
+            <td>
+                @php
+                    $class = match($help->status){
+                        'open' => 'badge border border-info text-info px-2 py-1 fs-13',
+                        'pending' => 'badge border border-warning text-warning px-2 py-1 fs-13',
+                        'on_hold' => 'badge border border-secondary text-secondary px-2 py-1 fs-13',
+                        'solved' => 'badge border border-success text-success px-2 py-1 fs-13',
+                        default => 'badge border border-dark text-dark px-2 py-1 fs-13'
+                    };
+                @endphp
+                <span class="{{ $class }}">{{ ucfirst(str_replace('_',' ',$help->status)) }}</span>
+            </td>
+            <td>{{ \Carbon\Carbon::parse($help->created_at)->format('d-m-Y') }}</td>
+            <td>
+                <a href="{{ route('vendor.help-support.show', $help->id) }}" class="btn btn-sm btn-soft-info" title="View">
+                    <i class="bi bi-eye"></i>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr><td colspan="5" class="text-center">No records found.</td></tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$helps" />
+    </tr>
+</tfoot>

--- a/resources/views/vendor/help_support/create.blade.php
+++ b/resources/views/vendor/help_support/create.blade.php
@@ -1,0 +1,123 @@
+@extends('vendor.layouts.app')
+@section('title', 'Add Help & Support | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">Add Help & Support</h4>
+                <a href="{{ route('vendor.help-support.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back to List</a>
+            </div>
+            <div class="card-body">
+                <form id="helpForm" action="{{ route('vendor.help-support.store') }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    <div class="row gy-3">
+                        <div class="col-md-6">
+                            <label for="name" class="form-label">Name <span class="text-danger">*</span></label>
+                            <input type="text" id="name" name="name" class="form-control" value="{{ old('name', auth()->user()->name) }}" placeholder="Your Name">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="contact_no" class="form-label">Contact No <span class="text-danger">*</span></label>
+                            <input type="text" id="contact_no" name="contact_no" class="form-control" value="{{ old('contact_no') }}" placeholder="Contact Number">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="email" class="form-label">Email <span class="text-danger">*</span></label>
+                            <input type="email" id="email" name="email" class="form-control" value="{{ old('email', auth()->user()->email) }}" placeholder="Email">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="attachment" class="form-label">Attachment</label>
+                            <input type="file" id="attachment" name="attachment" class="form-control">
+                        </div>
+                        <div class="col-md-12">
+                            <label for="message" class="form-label">Message <span class="text-danger">*</span></label>
+                            <textarea id="message" name="message" class="form-control" rows="4" placeholder="Message">{{ old('message') }}</textarea>
+                        </div>
+                    </div>
+                    <div class="mb-3 text-end">
+                        <button type="submit" class="btn btn-success"><i class="bx bx-save"></i> Submit</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    const $form = $('#helpForm');
+    const $btn = $form.find('button[type="submit"]');
+
+    function showError($input, msg){
+        $input.addClass('is-invalid');
+        $input.next('.invalid-feedback').remove();
+        $input.after(`<div class="invalid-feedback d-block">${msg}</div>`);
+        toastr.error(msg);
+    }
+
+    function clearError($input){
+        $input.removeClass('is-invalid');
+        $input.next('.invalid-feedback').remove();
+    }
+
+    function validateField($input, rules){
+        let ok = true;
+        const val = $input.val().trim();
+        for(const rule of rules){
+            if(rule.condition(val, $input)){
+                showError($input, rule.message);
+                ok = false;
+                break;
+            }
+        }
+        if(ok) clearError($input);
+        return ok;
+    }
+
+    const rules = {
+        name: [{condition:v=>!v,message:'Name is required.'}],
+        contact_no: [{condition:v=>!v,message:'Contact number is required.'}],
+        email: [
+            {condition:v=>!v,message:'Email is required.'},
+            {condition:v=>!/^([^\s@]+@[^\s@]+\.[^\s@]+)$/.test(v),message:'Enter valid email.'}
+        ],
+        message:[{condition:v=>!v,message:'Message is required.'}],
+        attachment:[{
+            condition:(v,$i)=>{if(!v) return false;const ext=v.split('.').pop().toLowerCase();return ['jpg','jpeg','png','pdf','doc','docx'].indexOf(ext)===-1;},
+            message:'Invalid file type.'
+        }]
+    };
+
+    $form.on('submit', function(e){
+        e.preventDefault();
+        $('.is-invalid').removeClass('is-invalid');
+        $('.invalid-feedback').remove();
+        let valid = true;
+        $.each(rules, function(field, r){
+            const $input = $('#' + field);
+            if(!validateField($input, r)) valid = false;
+        });
+        if(!valid) return;
+        const formData = new FormData(this);
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            beforeSend: function(){ $btn.prop('disabled', true); },
+            success: function(res){
+                toastr.success(res.message || 'Submitted successfully');
+                if(res.redirect){ window.location.href = res.redirect; }
+            },
+            error: function(xhr){
+                if(xhr.status===422){
+                    $.each(xhr.responseJSON.errors, function(k,v){ showError($('#'+k), v[0]); });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete:function(){ $btn.prop('disabled', false); }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/vendor/help_support/index.blade.php
+++ b/resources/views/vendor/help_support/index.blade.php
@@ -1,0 +1,121 @@
+@extends('vendor.layouts.app')
+@section('title', $pageTitle ?? 'Help & Support' . ' | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">{{ $pageTitle ?? 'Help & Support' }}</h4>
+                <a href="{{ route('vendor.help-support.create') }}" class="btn btn-sm btn-primary">
+                    <i class="bi bi-plus-lg"></i> Add Request
+                </a>
+            </div>
+            <div class="card-body">
+                <form id="filterForm" class="row g-2 align-items-end mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Name</label>
+                        <div class="input-group">
+                            <span class="input-group-text"><i class="bi bi-person"></i></span>
+                            <input type="text" id="name" class="form-control" placeholder="Name">
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Status</label>
+                        <div class="input-group">
+                            <span class="input-group-text"><i class="bi bi-check2-circle"></i></span>
+                            <select id="status" class="form-select">
+                                <option value="">Select</option>
+                                <option value="open">Open</option>
+                                <option value="pending">Pending</option>
+                                <option value="on_hold">On hold</option>
+                                <option value="solved">Solved</option>
+                                <option value="closed">Closed</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-5">
+                        <button type="button" id="search" class="btn btn-primary">
+                            <i class="bi bi-search"></i> SEARCH
+                        </button>
+                        <button type="button" id="reset" class="btn btn-outline-danger">
+                            <i class="bi bi-arrow-clockwise"></i> RESET
+                        </button>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0 table-hover table-centered" id="helps-table" style="width: 100%;">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>#</th>
+                                <th>Name</th>
+                                <th>Status</th>
+                                <th>Created At</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody id="helps-table-body-content">
+                            <tr><td colspan="5" class="text-center">Loading...</td></tr>
+                        </tbody>
+                        <tfoot id="helps-table-foot-content">
+                            <tr><td colspan="5" class="text-center"></td></tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    fetchHelps(1);
+    let currentAjax = null;
+
+    function fetchHelps(page = 1, perPage = null){
+        if(currentAjax && currentAjax.readyState !== 4){
+            currentAjax.abort();
+        }
+        $('#helps-table-body-content').html('<tr><td colspan="5" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+        $('#helps-table-foot-content').empty();
+        const data = {
+            name: $('#name').val(),
+            status: $('#status').val(),
+            page: page,
+            per_page: perPage || $('#perPage').val() || 10
+        };
+        currentAjax = $.ajax({
+            url: '{{ route('vendor.help-support.render-table') }}',
+            method: 'GET',
+            data: data,
+            success: function(res){
+                const $html = $(res);
+                $('#helps-table-body-content').html($html.filter('tbody').html());
+                $('#helps-table-foot-content').html($html.filter('tfoot').html());
+            },
+            error: function(xhr){
+                if(xhr.statusText === 'abort') return;
+                $('#helps-table-body-content').html('<tr><td colspan="5" class="text-center text-danger">Error loading data.</td></tr>');
+            },
+            complete: function(){
+                currentAjax = null;
+            }
+        });
+    }
+
+    $('#search').on('click', function(){
+        fetchHelps(1);
+    });
+    $('#reset').on('click', function(){
+        $('#filterForm').trigger('reset');
+        fetchHelps(1);
+    });
+    $(document).on('click', '#helps-table-foot-content a.page-link', function(e){
+        e.preventDefault();
+        const page = new URL($(this).attr('href')).searchParams.get('page');
+        if(page){ fetchHelps(page); }
+    });
+    $(document).on('change', '#perPage', function(){
+        fetchHelps(1, $(this).val());
+    });
+});
+</script>
+@endsection

--- a/resources/views/vendor/help_support/show.blade.php
+++ b/resources/views/vendor/help_support/show.blade.php
@@ -1,0 +1,54 @@
+@extends('vendor.layouts.app')
+@section('title', 'View Help & Support | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">Help & Support Details</h4>
+                <a href="{{ route('vendor.help-support.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back to List</a>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered">
+                    <tr>
+                        <th>Name</th>
+                        <td>{{ $help->name }}</td>
+                    </tr>
+                    <tr>
+                        <th>Contact No</th>
+                        <td>{{ $help->contact_no }}</td>
+                    </tr>
+                    <tr>
+                        <th>Email</th>
+                        <td>{{ $help->email }}</td>
+                    </tr>
+                    <tr>
+                        <th>Message</th>
+                        <td>{{ $help->message }}</td>
+                    </tr>
+                    @if($help->attachment)
+                    <tr>
+                        <th>Attachment</th>
+                        <td><a href="{{ asset('storage/'.$help->attachment) }}" target="_blank">View</a></td>
+                    </tr>
+                    @endif
+                    <tr>
+                        <th>Status</th>
+                        <td>{{ ucfirst(str_replace('_',' ',$help->status)) }}</td>
+                    </tr>
+                    @if($help->reply_message)
+                    <tr>
+                        <th>Reply</th>
+                        <td>{{ $help->reply_message }}</td>
+                    </tr>
+                    @endif
+                    <tr>
+                        <th>Created At</th>
+                        <td>{{ \Carbon\Carbon::parse($help->created_at)->format('d-m-Y') }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -188,6 +188,14 @@ Route::middleware(['auth'])->group(function () {
         Route::get('{id}', [VendorProductController::class, 'show'])->name('show');
         Route::delete('delete/{id}', [VendorProductController::class, 'destroy'])->name('destroy');
     });
+
+    Route::prefix('vendor/help-support')->name('vendor.help-support.')->group(function () {
+        Route::get('list', [App\Http\Controllers\Vendor\VendorHelpSupportController::class, 'index'])->name('index');
+        Route::get('render-table', [App\Http\Controllers\Vendor\VendorHelpSupportController::class, 'renderHelpsTable'])->name('render-table');
+        Route::get('create', [App\Http\Controllers\Vendor\VendorHelpSupportController::class, 'create'])->name('create');
+        Route::post('store', [App\Http\Controllers\Vendor\VendorHelpSupportController::class, 'store'])->name('store');
+        Route::get('{id}', [App\Http\Controllers\Vendor\VendorHelpSupportController::class, 'show'])->name('show');
+    });
 });
 
 Route::get('/buyer/dashboard', function () {


### PR DESCRIPTION
## Summary
- add migration for help_supports table
- add HelpSupport model
- add VendorHelpSupportController with CRUD logic for vendor
- add routes for help support
- add help support views for vendor

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685426d781b48327b8425a34ed657601