### PR TITLE
Fix AJAX init order

### DIFF
--- a/resources/views/vendor/help_support/index.blade.php
+++ b/resources/views/vendor/help_support/index.blade.php
@@ -67,8 +67,8 @@
 </div>
 <script>
 $(function(){
-    fetchHelps(1);
     let currentAjax = null;
+    fetchHelps(1);
 
     function fetchHelps(page = 1, perPage = null){
         if(currentAjax && currentAjax.readyState !== 4){


### PR DESCRIPTION
## Summary
- fix initialization order in `fetchHelps` script

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68542ba03fbc832794dfd72413308406