### PR TITLE
Add stock log modal with AJAX

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -52,4 +52,9 @@ class Product extends Model
         return $this->belongsTo(Category::class, 'category_id');
     }
 
+    public function stockLogs()
+    {
+        return $this->hasMany(StockLog::class);
+    }
+
 }

--- a/app/Models/StockLog.php
+++ b/app/Models/StockLog.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class StockLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'user_id',
+        'old_quantity',
+        'new_quantity',
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_06_20_205514_create_stock_logs_table.php
+++ b/database/migrations/2025_06_20_205514_create_stock_logs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stock_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('old_quantity');
+            $table->integer('new_quantity');
+            $table->timestamps();
+
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stock_logs');
+    }
+};

--- a/resources/views/vendor/inventory/_inventory_table.blade.php
+++ b/resources/views/vendor/inventory/_inventory_table.blade.php
@@ -7,6 +7,7 @@
     <td>{{ \Carbon\Carbon::parse($product->updated_at)->format('d-m-Y') }}</td>
     <td>
         <button class="btn btn-sm btn-primary update-stock" data-id="{{ $product->id }}"><i class="bi bi-save"></i> Update</button>
+        <button class="btn btn-sm btn-info view-stock-log" data-id="{{ $product->id }}"><i class="bi bi-clock-history"></i> Stock Log</button>
     </td>
 </tr>
 @empty

--- a/resources/views/vendor/inventory/_stock_logs.blade.php
+++ b/resources/views/vendor/inventory/_stock_logs.blade.php
@@ -1,0 +1,35 @@
+<div class="table-responsive">
+    <table class="table table-bordered">
+        <thead class="bg-light-subtle">
+            <tr>
+                <th>#</th>
+                <th>Old Qty</th>
+                <th>New Qty</th>
+                <th>User</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($logs as $log)
+                <tr>
+                    <td>{{ ($logs->currentPage() - 1) * $logs->perPage() + $loop->iteration }}</td>
+                    <td>{{ $log->old_quantity }}</td>
+                    <td>{{ $log->new_quantity }}</td>
+                    <td>{{ $log->user->name }}</td>
+                    <td>{{ \Carbon\Carbon::parse($log->created_at)->format('d-m-Y') }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="text-center">No records found.</td>
+                </tr>
+            @endforelse
+        </tbody>
+        <tfoot>
+            <tr>
+                <td colspan="5" class="text-center">
+                    <x-custom-pagination :paginator="$logs" />
+                </td>
+            </tr>
+        </tfoot>
+    </table>
+</div>

--- a/resources/views/vendor/inventory/index.blade.php
+++ b/resources/views/vendor/inventory/index.blade.php
@@ -57,6 +57,28 @@
                 </div>
             </div>
         </div>
+</div>
+</div>
+<!-- Stock Log Modal -->
+<div class="modal fade" id="stockLogModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Stock Logs</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" id="stockLogModalBody">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="card">
+                            <div class="card-body" id="stock-log-content">
+                                <!-- Logs will load here -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <script>
@@ -117,6 +139,29 @@ $(document).ready(function(){
             error:function(xhr){ if(xhr.responseJSON && xhr.responseJSON.message){ toastr.error(xhr.responseJSON.message); } else { toastr.error('Error updating stock.'); } }
         });
     });
+
+    $(document).on('click','.view-stock-log',function(){
+        const id=$(this).data('id');
+        $('#stockLogModal').data('product-id', id).modal('show');
+        fetchStockLogs(id,1);
+    });
+
+    $(document).on('click','#stock-log-content a.page-link',function(e){
+        e.preventDefault();
+        const page=new URL($(this).attr('href')).searchParams.get('page');
+        const id=$('#stockLogModal').data('product-id');
+        fetchStockLogs(id,page);
+    });
+
+    function fetchStockLogs(id,page){
+        $('#stock-log-content').html('<div class="text-center p-3"><div class="spinner-border" role="status"></div></div>');
+        $.ajax({
+            url:'{{ url('vendor/inventory') }}/'+id+'/logs',
+            data:{ page: page },
+            success:function(res){ $('#stock-log-content').html(res); },
+            error:function(){ $('#stock-log-content').html('<p class="text-danger text-center">Error loading logs.</p>'); }
+        });
+    }
 });
 </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -204,6 +204,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('list', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'index'])->name('index');
         Route::get('render-table', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'renderInventoryTable'])->name('render-table');
         Route::post('update/{id}', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'updateStock'])->name('update');
+        Route::get('{id}/logs', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'stockLogs'])->name('logs');
     });
 });
 


### PR DESCRIPTION
## Summary
- track product stock changes in new `stock_logs` table
- show a Stock Log button and modal on the vendor inventory page
- fetch log entries via AJAX and display them in a paginated table

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6855ca106b5c8327890b49b92dab741a