### PR TITLE
Fix stock log pagination layout

### DIFF
--- a/resources/views/vendor/inventory/_stock_logs.blade.php
+++ b/resources/views/vendor/inventory/_stock_logs.blade.php
@@ -26,9 +26,7 @@
         </tbody>
         <tfoot>
             <tr>
-                <td colspan="5" class="text-center">
-                    <x-custom-pagination :paginator="$logs" />
-                </td>
+                <x-custom-pagination :paginator="$logs" />
             </tr>
         </tfoot>
     </table>


### PR DESCRIPTION
## Summary
- fix markup for custom pagination in stock log table

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cdaffb50832797eceb5657912142