### PR TITLE
Add warehouse management feature for vendors

### DIFF
--- a/app/Http/Controllers/Vendor/WarehouseController.php
+++ b/app/Http/Controllers/Vendor/WarehouseController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use App\Models\Warehouse;
+
+class WarehouseController extends Controller
+{
+    /**
+     * Display the warehouses list page.
+     */
+    public function index()
+    {
+        return view('vendor.warehouses.index');
+    }
+
+    /**
+     * Render paginated warehouses table via AJAX.
+     */
+    public function renderTable(Request $request)
+    {
+        $query = Warehouse::where('vendor_id', Auth::id());
+
+        if ($request->filled('name')) {
+            $query->where('name', 'like', '%' . $request->name . '%');
+        }
+
+        $warehouses = $query->orderBy('created_at', 'desc')
+                           ->paginate($request->input('per_page', 10));
+
+        return view('vendor.warehouses._table', compact('warehouses'));
+    }
+
+    /**
+     * Store a newly created warehouse via AJAX.
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name'    => 'required|string|max:255',
+            'address' => 'nullable|string|max:255',
+            'city'    => 'nullable|string|max:100',
+            'state'   => 'nullable|string|max:100',
+            'pincode' => 'nullable|string|max:20',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => false,
+                'message' => $validator->errors()->first(),
+            ], 422);
+        }
+
+        Warehouse::create(array_merge($validator->validated(), [
+            'vendor_id' => Auth::id(),
+        ]));
+
+        return response()->json([
+            'status'  => true,
+            'message' => 'Warehouse saved successfully.',
+        ]);
+    }
+
+    /**
+     * Update the specified warehouse via AJAX.
+     */
+    public function update(Request $request, $id)
+    {
+        $warehouse = Warehouse::where('id', $id)
+            ->where('vendor_id', Auth::id())
+            ->firstOrFail();
+
+        $validator = Validator::make($request->all(), [
+            'name'    => 'required|string|max:255',
+            'address' => 'nullable|string|max:255',
+            'city'    => 'nullable|string|max:100',
+            'state'   => 'nullable|string|max:100',
+            'pincode' => 'nullable|string|max:20',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => false,
+                'message' => $validator->errors()->first(),
+            ], 422);
+        }
+
+        $warehouse->update($validator->validated());
+
+        return response()->json([
+            'status'  => true,
+            'message' => 'Warehouse updated successfully.',
+        ]);
+    }
+
+    /**
+     * Remove the specified warehouse via AJAX.
+     */
+    public function destroy($id)
+    {
+        $warehouse = Warehouse::where('id', $id)
+            ->where('vendor_id', Auth::id())
+            ->firstOrFail();
+
+        $warehouse->delete();
+
+        return response()->json([
+            'status'  => true,
+            'message' => 'Warehouse deleted successfully.',
+        ]);
+    }
+}
+

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use App\Models\BuyerProfile; // Import BuyerProfile
 use App\Models\Role;
 use App\Models\VendorSubscription;
+use App\Models\Warehouse;
 
 
 class User extends Authenticatable
@@ -93,6 +94,11 @@ class User extends Authenticatable
     public function products()
     {
         return $this->hasMany(\App\Models\Product::class, 'vendor_id');
+    }
+
+    public function warehouses()
+    {
+        return $this->hasMany(Warehouse::class, 'vendor_id');
     }
 
     public function roles(): BelongsToMany

--- a/app/Models/Warehouse.php
+++ b/app/Models/Warehouse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Warehouse extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'vendor_id',
+        'name',
+        'address',
+        'city',
+        'state',
+        'pincode',
+    ];
+
+    public function vendor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'vendor_id');
+    }
+}

--- a/database/migrations/2025_06_21_030700_create_warehouses_table.php
+++ b/database/migrations/2025_06_21_030700_create_warehouses_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('warehouses', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('vendor_id');
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->string('city')->nullable();
+            $table->string('state')->nullable();
+            $table->string('pincode')->nullable();
+            $table->timestamps();
+
+            $table->foreign('vendor_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('warehouses');
+    }
+};

--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -313,6 +313,9 @@
                     ['title' => 'Inventory Management', 'icon' => 'bi-stack', 'id' => 'sidebarInventory', 'items' => [
                         ['name' => 'Inventory List', 'route' => 'vendor.inventory.index'],
                     ]],
+                    ['title' => 'Warehouses', 'icon' => 'bi-building', 'id' => 'sidebarWarehouses', 'items' => [
+                        ['name' => 'Warehouse List', 'route' => 'vendor.warehouses.index'],
+                    ]],
                     ['title' => 'Help & Support', 'icon' => 'bi-question-circle', 'id' => 'sidebarHelpSupport', 'items' => [
                         ['name' => 'Add Request', 'route' => 'vendor.help-support.create'],
                         ['name' => 'Request List', 'route' => 'vendor.help-support.index'],

--- a/resources/views/vendor/warehouses/_table.blade.php
+++ b/resources/views/vendor/warehouses/_table.blade.php
@@ -1,0 +1,28 @@
+<tbody>
+@forelse($warehouses as $warehouse)
+<tr>
+    <td>{{ ($warehouses->currentPage() - 1) * $warehouses->perPage() + $loop->iteration }}</td>
+    <td>{{ $warehouse->name }}</td>
+    <td>{{ $warehouse->city }}</td>
+    <td>{{ $warehouse->state }}</td>
+    <td>{{ $warehouse->created_at->format('d-m-Y') }}</td>
+    <td>
+        <button class="btn btn-sm btn-warning edit-warehouse" data-id="{{ $warehouse->id }}" data-info='@json($warehouse->only(['name','address','city','state','pincode']))'>
+            <i class="bi bi-pencil"></i>
+        </button>
+        <button class="btn btn-sm btn-danger delete-warehouse" data-id="{{ $warehouse->id }}">
+            <i class="bi bi-trash"></i>
+        </button>
+    </td>
+</tr>
+@empty
+<tr>
+    <td colspan="6" class="text-center">No records found.</td>
+</tr>
+@endforelse
+</tbody>
+<tfoot>
+<tr>
+    <x-custom-pagination :paginator="$warehouses" />
+</tr>
+</tfoot>

--- a/resources/views/vendor/warehouses/index.blade.php
+++ b/resources/views/vendor/warehouses/index.blade.php
@@ -1,0 +1,142 @@
+@extends('vendor.layouts.app')
+@section('title', 'Warehouse Management | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">Warehouse Management</h4>
+                <button type="button" class="btn btn-sm btn-primary" id="addWarehouseBtn">
+                    <i class="bi bi-plus-lg"></i> Add Warehouse
+                </button>
+            </div>
+            <div class="card-body">
+                <form id="filterForm" class="row g-2 align-items-end mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Name</label>
+                        <div class="input-group">
+                            <span class="input-group-text"><i class="bi bi-box"></i></span>
+                            <input type="text" id="name" class="form-control" placeholder="Name">
+                        </div>
+                    </div>
+                    <div class="col-md-8">
+                        <button type="button" id="search" class="btn btn-primary">
+                            <i class="bi bi-search"></i> SEARCH
+                        </button>
+                        <button type="button" id="reset" class="btn btn-outline-danger">
+                            <i class="bi bi-arrow-clockwise"></i> RESET
+                        </button>
+                    </div>
+                </form>
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0 table-hover table-centered" id="warehouse-table" style="width: 100%;">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>#</th>
+                                <th>Name</th>
+                                <th>City</th>
+                                <th>State</th>
+                                <th>Created At</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody id="warehouse-table-body-content">
+                            <tr><td colspan="6" class="text-center">Loading...</td></tr>
+                        </tbody>
+                        <tfoot id="warehouse-table-foot-content">
+                            <tr><td colspan="6" class="text-center"></td></tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="warehouseModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Warehouse</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="warehouseForm">
+                    <input type="hidden" id="warehouse_id" value="">
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <input type="text" class="form-control" id="w_name" name="name" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Address</label>
+                        <input type="text" class="form-control" id="w_address" name="address">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">City</label>
+                        <input type="text" class="form-control" id="w_city" name="city">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">State</label>
+                        <input type="text" class="form-control" id="w_state" name="state">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Pincode</label>
+                        <input type="text" class="form-control" id="w_pincode" name="pincode">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="saveWarehouse">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+$(function(){
+    const modal = new bootstrap.Modal(document.getElementById('warehouseModal'));
+    let currentAjax = null;
+
+    fetchWarehouses(1);
+
+    function fetchWarehouses(page=1, perPage=null){
+        if(currentAjax && currentAjax.readyState !== 4){ currentAjax.abort(); }
+        $('#warehouse-table-body-content').html('<tr><td colspan="6" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+        $('#warehouse-table-foot-content').empty();
+        const data = { name: $('#name').val(), page: page, per_page: perPage || $('#perPage').val() || 10 };
+        currentAjax = $.ajax({
+            url: '{{ route('vendor.warehouses.render-table') }}',
+            method: 'GET',
+            data: data,
+            success: function(res){ const $html = $(res); $('#warehouse-table-body-content').html($html.filter('tbody').html()); $('#warehouse-table-foot-content').html($html.filter('tfoot').html()); },
+            error: function(xhr){ if(xhr.statusText==='abort') return; $('#warehouse-table-body-content').html('<tr><td colspan="6" class="text-center text-danger">Error loading data.</td></tr>'); },
+            complete: function(){ currentAjax = null; }
+        });
+    }
+
+    $('#search').on('click', function(){ fetchWarehouses(1); });
+    $('#reset').on('click', function(){ $('#filterForm').trigger('reset'); fetchWarehouses(1); });
+    $(document).on('click', '#warehouse-table-foot-content a.page-link', function(e){ e.preventDefault(); const page = new URL($(this).attr('href')).searchParams.get('page'); if(page){ fetchWarehouses(page); } });
+    $(document).on('change', '#perPage', function(){ fetchWarehouses(1, $(this).val()); });
+
+    $('#addWarehouseBtn').on('click', function(){ $('#warehouseForm')[0].reset(); $('#warehouse_id').val(''); modal.show(); });
+    $(document).on('click', '.edit-warehouse', function(){ const info = $(this).data('info'); $('#warehouse_id').val($(this).data('id')); $('#w_name').val(info.name); $('#w_address').val(info.address); $('#w_city').val(info.city); $('#w_state').val(info.state); $('#w_pincode').val(info.pincode); modal.show(); });
+
+    $('#saveWarehouse').on('click', function(){
+        const id = $('#warehouse_id').val();
+        const url = id ? '{{ url('vendor/warehouses/update') }}/'+id : '{{ route('vendor.warehouses.store') }}';
+        $.ajax({
+            url: url,
+            method: id ? 'PUT' : 'POST',
+            data: $('#warehouseForm').serialize(),
+            success: function(res){ if(res.status){ toastr.success(res.message); modal.hide(); fetchWarehouses(1); } },
+            error: function(xhr){ if(xhr.responseJSON && xhr.responseJSON.message){ toastr.error(xhr.responseJSON.message); } else { toastr.error('Error'); } }
+        });
+    });
+
+    $(document).on('click', '.delete-warehouse', function(){ if(!confirm('Delete this warehouse?')) return; const id=$(this).data('id'); $.ajax({ url:'{{ url('vendor/warehouses/delete') }}/'+id, method:'DELETE', data:{_token:'{{ csrf_token() }}'}, success:function(res){ if(res.status){ toastr.success(res.message); fetchWarehouses(1); } }, error:function(){ toastr.error('Error'); } }); });
+});
+</script>
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -206,6 +206,14 @@ Route::middleware(['auth'])->group(function () {
         Route::post('update/{id}', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'updateStock'])->name('update');
         Route::get('{id}/logs', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'stockLogs'])->name('logs');
     });
+
+    Route::prefix('vendor/warehouses')->name('vendor.warehouses.')->group(function () {
+        Route::get('list', [App\Http\Controllers\Vendor\WarehouseController::class, 'index'])->name('index');
+        Route::get('render-table', [App\Http\Controllers\Vendor\WarehouseController::class, 'renderTable'])->name('render-table');
+        Route::post('store', [App\Http\Controllers\Vendor\WarehouseController::class, 'store'])->name('store');
+        Route::put('update/{id}', [App\Http\Controllers\Vendor\WarehouseController::class, 'update'])->name('update');
+        Route::delete('delete/{id}', [App\Http\Controllers\Vendor\WarehouseController::class, 'destroy'])->name('delete');
+    });
 });
 
 Route::get('/buyer/dashboard', function () {


### PR DESCRIPTION
## Summary
- add migration and model for warehouses
- implement `WarehouseController` for vendors with AJAX endpoints
- create warehouse listing and modal form in vendor dashboard
- register warehouse routes and menu link
- update user model for warehouse relation
- include views for AJAX rendering and pagination

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68562162fe6083279c5bea1a8394ff72