### PR TITLE
Fix CSRF token mismatch for warehouse AJAX

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A fully responsive premium admin dashboard template" />
     <meta name="author" content="Techzaa" />
+    <meta name="csrf-token" content="{{ csrf_token() }}" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <!-- App favicon -->
@@ -28,6 +29,13 @@
     <!-- Theme Config js -->
     <script src="{{ asset('assets/js/config.js') }}"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script>
+        $.ajaxSetup({
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+            }
+        });
+    </script>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>

--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -6,6 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A fully responsive premium admin dashboard template" />
 <meta name="author" content="Techzaa" />
+<meta name="csrf-token" content="{{ csrf_token() }}" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
 <!-- App favicon -->
@@ -26,6 +27,13 @@
 <!-- Theme Config js -->
 <script src="{{ asset('assets/js/config.js') }}"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script>
+    $.ajaxSetup({
+        headers: {
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+        }
+    });
+</script>
 
 <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>

--- a/resources/views/vendor/warehouses/index.blade.php
+++ b/resources/views/vendor/warehouses/index.blade.php
@@ -171,7 +171,6 @@ $(function(){
             url: url,
             method: id ? 'PUT' : 'POST',
             data: $('#warehouseForm').serialize(),
-            headers: { 'X-CSRF-TOKEN': '{{ csrf_token() }}' },
             success: function(res){ if(res.status){ toastr.success(res.message); modal.hide(); fetchWarehouses(1); } },
             error: function(xhr){
                 if(xhr.status === 422 && xhr.responseJSON.errors){
@@ -188,7 +187,7 @@ $(function(){
         });
     });
 
-    $(document).on('click', '.delete-warehouse', function(){ if(!confirm('Delete this warehouse?')) return; const id=$(this).data('id'); $.ajax({ url:'{{ url('vendor/warehouses/delete') }}/'+id, method:'DELETE', data:{_token:'{{ csrf_token() }}'}, success:function(res){ if(res.status){ toastr.success(res.message); fetchWarehouses(1); } }, error:function(){ toastr.error('Error'); } }); });
+    $(document).on('click', '.delete-warehouse', function(){ if(!confirm('Delete this warehouse?')) return; const id=$(this).data('id'); $.ajax({ url:'{{ url('vendor/warehouses/delete') }}/'+id, method:'DELETE', success:function(res){ if(res.status){ toastr.success(res.message); fetchWarehouses(1); } }, error:function(){ toastr.error('Error'); } }); });
 });
 </script>
 @endsection


### PR DESCRIPTION
## Summary
- add CSRF meta tag and jQuery AJAX setup in vendor and admin layouts
- rely on global AJAX CSRF handling in warehouse page

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685627819b808327ad8641fae9a15c3c