### PR TITLE
Add warehouse filter to inventory management

### DIFF
--- a/app/Models/Warehouse.php
+++ b/app/Models/Warehouse.php
@@ -5,6 +5,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\WarehouseProduct;
+use App\Models\Product;
 
 class Warehouse extends Model
 {
@@ -22,5 +26,17 @@ class Warehouse extends Model
     public function vendor(): BelongsTo
     {
         return $this->belongsTo(User::class, 'vendor_id');
+    }
+
+    public function productStocks(): HasMany
+    {
+        return $this->hasMany(WarehouseProduct::class);
+    }
+
+    public function products(): BelongsToMany
+    {
+        return $this->belongsToMany(Product::class, 'warehouse_product')
+                    ->withPivot('quantity')
+                    ->withTimestamps();
     }
 }

--- a/app/Models/WarehouseProduct.php
+++ b/app/Models/WarehouseProduct.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WarehouseProduct extends Model
+{
+    protected $table = 'warehouse_product';
+
+    protected $fillable = [
+        'warehouse_id',
+        'product_id',
+        'quantity',
+    ];
+
+    public function warehouse()
+    {
+        return $this->belongsTo(Warehouse::class);
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/database/migrations/2025_06_22_000000_create_warehouse_product_table.php
+++ b/database/migrations/2025_06_22_000000_create_warehouse_product_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('warehouse_product', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('warehouse_id');
+            $table->unsignedBigInteger('product_id');
+            $table->integer('quantity')->default(0);
+            $table->timestamps();
+
+            $table->foreign('warehouse_id')->references('id')->on('warehouses')->onDelete('cascade');
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade');
+            $table->unique(['warehouse_id', 'product_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('warehouse_product');
+    }
+};

--- a/resources/views/vendor/inventory/_inventory_table.blade.php
+++ b/resources/views/vendor/inventory/_inventory_table.blade.php
@@ -3,7 +3,13 @@
 <tr>
     <td>{{ ($products->currentPage() - 1) * $products->perPage() + $loop->iteration }}</td>
     <td>{{ $product->product_name }}</td>
-    <td>{{ $product->stock_quantity }}</td>
+    <td>
+        @if(isset($warehouseId) && $warehouseId)
+            {{ $product->warehouseStocks->first()->quantity ?? 0 }}
+        @else
+            {{ $product->stock_quantity }}
+        @endif
+    </td>
     <td><input type="number" class="form-control form-control-sm stock-input-in" value="0" min="0"></td>
     <td><input type="number" class="form-control form-control-sm stock-input-out" value="0" min="0"></td>
     <td>{{ \Carbon\Carbon::parse($product->updated_at)->format('d-m-Y') }}</td>

--- a/resources/views/vendor/inventory/index.blade.php
+++ b/resources/views/vendor/inventory/index.blade.php
@@ -23,7 +23,19 @@
                             <input type="text" id="product_name" class="form-control" placeholder="Product Name">
                         </div>
                     </div>
-                    <div class="col-md-8">
+                    <div class="col-md-4">
+                        <label class="form-label">Warehouse</label>
+                        <div class="input-group">
+                            <span class="input-group-text"><i class="bi bi-shop"></i></span>
+                            <select id="warehouse_filter" class="form-select">
+                                <option value="">All Warehouses</option>
+                                @foreach($warehouses as $w)
+                                    <option value="{{ $w->id }}">{{ $w->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
                         <button type="button" id="search" class="btn btn-primary">
                             <i class="bi bi-search"></i> SEARCH
                         </button>
@@ -38,7 +50,7 @@
                             <tr>
                                 <th>#</th>
                                 <th>Name</th>
-                                <th>Current Stock</th>
+                                <th>Warehouse Stock</th>
                                 <th>In Stock</th>
                                 <th>Out Stock</th>
                                 <th>Updated At</th>
@@ -94,7 +106,7 @@ $(document).ready(function(){
         }
         $('#inventory-table-body-content').html('<tr><td colspan="7" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
         $('#inventory-table-foot-content').empty();
-        const filters = { product_name: $('#product_name').val() };
+        const filters = { product_name: $('#product_name').val(), warehouse_id: $('#warehouse_filter').val() };
         perPage = perPage || $('#perPage').val() || 10;
         currentAjaxRequest = $.ajax({
             url: "{{ route('vendor.inventory.render-table') }}",
@@ -126,11 +138,21 @@ $(document).ready(function(){
         fetchInventoryData(1, $(this).val());
     });
 
+    $('#warehouse_filter').on('change', function(){
+        fetchInventoryData(1);
+    });
+
     $(document).on('click','.update-stock',function(){
         const id = $(this).data('id');
         const $row = $(this).closest('tr');
         const inQty = $row.find('.stock-input-in').val();
         const outQty = $row.find('.stock-input-out').val();
+        const warehouseId = $('#warehouse_filter').val();
+
+        if(!warehouseId){
+            toastr.error('Please select a warehouse.');
+            return;
+        }
 
         if(!/^\d*$/.test(inQty) || !/^\d*$/.test(outQty)){
             toastr.error('Please enter valid quantities.');
@@ -148,7 +170,7 @@ $(document).ready(function(){
         $.ajax({
             url: '{{ url('vendor/inventory/update') }}/'+id,
             type:'POST',
-            data:{ _token:'{{ csrf_token() }}', in_stock: inVal, out_stock: outVal },
+            data:{ _token:'{{ csrf_token() }}', in_stock: inVal, out_stock: outVal, warehouse_id: warehouseId },
             success:function(res){
                 if(res.status==1){
                     toastr.success(res.message);


### PR DESCRIPTION
## Summary
- add migration for product stock per warehouse
- support per-warehouse relations in models
- load vendor warehouses in inventory controller and filter results
- validate warehouse when updating stock
- update inventory views with warehouse dropdown and ajax handling

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685629cd7cd88327b8e9e8a3e4a859c9