### PR TITLE
Add per-row warehouse stock updates

### DIFF
--- a/resources/views/vendor/inventory/_inventory_table.blade.php
+++ b/resources/views/vendor/inventory/_inventory_table.blade.php
@@ -4,6 +4,14 @@
     <td>{{ ($products->currentPage() - 1) * $products->perPage() + $loop->iteration }}</td>
     <td>{{ $product->product_name }}</td>
     <td>
+        <select class="form-select form-select-sm warehouse-select" data-product-id="{{ $product->id }}">
+            <option value="">Select</option>
+            @foreach($warehouses as $w)
+                <option value="{{ $w->id }}" @selected(isset($warehouseId) && $warehouseId == $w->id)>{{ $w->name }}</option>
+            @endforeach
+        </select>
+    </td>
+    <td class="current-stock" data-default="{{ $product->stock_quantity }}">
         @if(isset($warehouseId) && $warehouseId)
             {{ $product->warehouseStocks->first()->quantity ?? 0 }}
         @else
@@ -20,7 +28,7 @@
 </tr>
 @empty
 <tr>
-    <td colspan="7" class="text-center">No records found.</td>
+    <td colspan="8" class="text-center">No records found.</td>
 </tr>
 @endforelse
 </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -203,6 +203,7 @@ Route::middleware(['auth'])->group(function () {
     Route::prefix('vendor/inventory')->name('vendor.inventory.')->group(function () {
         Route::get('list', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'index'])->name('index');
         Route::get('render-table', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'renderInventoryTable'])->name('render-table');
+        Route::get('stock/{id}', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'getWarehouseStock'])->name('stock');
         Route::post('update/{id}', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'updateStock'])->name('update');
         Route::get('{id}/logs', [App\Http\Controllers\Vendor\VendorInventoryController::class, 'stockLogs'])->name('logs');
     });


### PR DESCRIPTION
## Summary
- allow selecting warehouse per item in inventory
- expose endpoint to fetch stock per warehouse
- update inventory table layout and Ajax logic
- register route for new stock endpoint

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856375f55f88327943871893c8caf11