### PR TITLE
Add product count to warehouse list

### DIFF
--- a/app/Http/Controllers/Vendor/WarehouseController.php
+++ b/app/Http/Controllers/Vendor/WarehouseController.php
@@ -23,7 +23,7 @@ class WarehouseController extends Controller
      */
     public function renderTable(Request $request)
     {
-        $query = Warehouse::where('vendor_id', Auth::id());
+        $query = Warehouse::withCount('products')->where('vendor_id', Auth::id());
 
         if ($request->filled('name')) {
             $query->where('name', 'like', '%' . $request->name . '%');
@@ -45,7 +45,7 @@ class WarehouseController extends Controller
             'address' => 'nullable|string|max:255',
             'city'    => 'nullable|string|max:100',
             'state'   => 'nullable|string|max:100',
-            'pincode' => 'nullable|string|max:20',
+            'pincode' => 'nullable|regex:/^\d+$/|max:20',
         ]);
 
         if ($validator->fails()) {
@@ -80,7 +80,7 @@ class WarehouseController extends Controller
             'address' => 'nullable|string|max:255',
             'city'    => 'nullable|string|max:100',
             'state'   => 'nullable|string|max:100',
-            'pincode' => 'nullable|string|max:20',
+            'pincode' => 'nullable|regex:/^\d+$/|max:20',
         ]);
 
         if ($validator->fails()) {

--- a/resources/views/vendor/warehouses/_table.blade.php
+++ b/resources/views/vendor/warehouses/_table.blade.php
@@ -5,6 +5,7 @@
     <td>{{ $warehouse->name }}</td>
     <td>{{ $warehouse->city }}</td>
     <td>{{ $warehouse->state }}</td>
+    <td>{{ $warehouse->products_count }}</td>
     <td>{{ $warehouse->created_at->format('d-m-Y') }}</td>
     <td>
         <button class="btn btn-sm btn-warning edit-warehouse" data-id="{{ $warehouse->id }}" data-info='@json($warehouse->only(["name","address","city","state","pincode"]))'>
@@ -17,7 +18,7 @@
 </tr>
 @empty
 <tr>
-    <td colspan="6" class="text-center">No records found.</td>
+    <td colspan="7" class="text-center">No records found.</td>
 </tr>
 @endforelse
 </tbody>

--- a/resources/views/vendor/warehouses/index.blade.php
+++ b/resources/views/vendor/warehouses/index.blade.php
@@ -36,15 +36,16 @@
                                 <th>Name</th>
                                 <th>City</th>
                                 <th>State</th>
+                                <th>Products</th>
                                 <th>Created At</th>
                                 <th>Action</th>
                             </tr>
                         </thead>
                         <tbody id="warehouse-table-body-content">
-                            <tr><td colspan="6" class="text-center">Loading...</td></tr>
+                            <tr><td colspan="7" class="text-center">Loading...</td></tr>
                         </tbody>
                         <tfoot id="warehouse-table-foot-content">
-                            <tr><td colspan="6" class="text-center"></td></tr>
+                            <tr><td colspan="7" class="text-center"></td></tr>
                         </tfoot>
                     </table>
                 </div>
@@ -100,6 +101,9 @@ $(function(){
     const rules = {
         w_name: [
             {condition: v => !v.trim(), message: 'Name is required.'}
+        ],
+        w_pincode: [
+            {condition: v => v && !/^\d+$/.test(v), message: 'Pincode must be numeric.'}
         ]
     };
 
@@ -133,7 +137,7 @@ $(function(){
 
     function fetchWarehouses(page=1, perPage=null){
         if(currentAjax && currentAjax.readyState !== 4){ currentAjax.abort(); }
-        $('#warehouse-table-body-content').html('<tr><td colspan="6" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
+        $('#warehouse-table-body-content').html('<tr><td colspan="7" class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></td></tr>');
         $('#warehouse-table-foot-content').empty();
         const data = { name: $('#name').val(), page: page, per_page: perPage || $('#perPage').val() || 10 };
         currentAjax = $.ajax({
@@ -141,7 +145,7 @@ $(function(){
             method: 'GET',
             data: data,
             success: function(res){ const $html = $(res); $('#warehouse-table-body-content').html($html.filter('tbody').html()); $('#warehouse-table-foot-content').html($html.filter('tfoot').html()); },
-            error: function(xhr){ if(xhr.statusText==='abort') return; $('#warehouse-table-body-content').html('<tr><td colspan="6" class="text-center text-danger">Error loading data.</td></tr>'); },
+            error: function(xhr){ if(xhr.statusText==='abort') return; $('#warehouse-table-body-content').html('<tr><td colspan="7" class="text-center text-danger">Error loading data.</td></tr>'); },
             complete: function(){ currentAjax = null; }
         });
     }


### PR DESCRIPTION
## Summary
- display product count for each warehouse
- enforce numeric pincode on server and client

## Testing
- `composer test` *(fails: composer not installed)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685639bdf0d0832792d9d7bfe768505e