### PR TITLE
Add warehouse field to product forms

### DIFF
--- a/resources/views/vendor/products/create.blade.php
+++ b/resources/views/vendor/products/create.blade.php
@@ -33,7 +33,7 @@
 <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote-lite.min.js"></script>
 
 <div class="row">
-    <div class="col-xl-12">
+    <div class="col-md-12">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center gap-1">
                 <h4 class="card-title flex-grow-1">Add New Product</h4>
@@ -110,6 +110,17 @@
                         <div class="col-md-4">
                             <label for="stock_quantity" class="form-label">Stock Quantity <span class="text-danger">*</span></label>
                             <input type="number" name="stock_quantity" id="stock_quantity" class="form-control" placeholder="0" min="0" value="{{ old('stock_quantity', 0) }}" />
+                        </div>
+
+                        {{-- Warehouse --}}
+                        <div class="col-md-4">
+                            <label for="warehouse_id" class="form-label">Warehouse <span class="text-danger">*</span></label>
+                            <select name="warehouse_id" id="warehouse_id" class="form-select">
+                                <option value="">-- Select Warehouse --</option>
+                                @foreach($warehouses as $warehouse)
+                                    <option value="{{ $warehouse->id }}" {{ old('warehouse_id') == $warehouse->id ? 'selected' : '' }}>{{ $warehouse->name }}</option>
+                                @endforeach
+                            </select>
                         </div>
 
                         {{-- HSN Code --}}
@@ -278,6 +289,14 @@ $(document).ready(function () {
             $('#stock_quantity').addClass('is-invalid');
             $('#stock_quantity').after('<span class="error error-message">Stock quantity cannot be negative</span>');
             toastr.error('Stock quantity cannot be negative');
+            isValid = false;
+        }
+
+        // Validate warehouse
+        if (!$('#warehouse_id').val()) {
+            $('#warehouse_id').addClass('is-invalid');
+            $('#warehouse_id').after('<span class="error error-message">Please select a warehouse</span>');
+            toastr.error('Please select a warehouse');
             isValid = false;
         }
         

--- a/resources/views/vendor/products/edit.blade.php
+++ b/resources/views/vendor/products/edit.blade.php
@@ -44,7 +44,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 
 <div class="row">
-    <div class="col-xl-12">
+    <div class="col-md-12">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center gap-1">
                 <h4 class="card-title flex-grow-1">Edit Product</h4>
@@ -126,7 +126,18 @@
                         <div class="col-md-4">
                             <label for="stock_quantity" class="form-label">Stock Quantity <span class="text-danger">*</span></label>
                             <input type="number" name="stock_quantity" id="stock_quantity" class="form-control" placeholder="0" min="0" value="{{ old('stock_quantity', $product->stock_quantity) }}" required />
-                            
+
+                        </div>
+
+                        {{-- Warehouse --}}
+                        <div class="col-md-4">
+                            <label for="warehouse_id" class="form-label">Warehouse <span class="text-danger">*</span></label>
+                            <select name="warehouse_id" id="warehouse_id" class="form-select">
+                                <option value="">-- Select Warehouse --</option>
+                                @foreach($warehouses as $warehouse)
+                                    <option value="{{ $warehouse->id }}" {{ old('warehouse_id', $product->warehouses->first()->id ?? '') == $warehouse->id ? 'selected' : '' }}>{{ $warehouse->name }}</option>
+                                @endforeach
+                            </select>
                         </div>
 
                         {{-- HSN Code --}}
@@ -305,6 +316,14 @@ $(document).ready(function () {
             $('#stock_quantity').addClass('is-invalid');
             $('#stock_quantity').after('<span class="error error-message">Stock quantity cannot be negative</span>');
             toastr.error('Stock quantity cannot be negative');
+            isValid = false;
+        }
+
+        // Validate warehouse
+        if (!$('#warehouse_id').val()) {
+            $('#warehouse_id').addClass('is-invalid');
+            $('#warehouse_id').after('<span class="error error-message">Please select a warehouse</span>');
+            toastr.error('Please select a warehouse');
             isValid = false;
         }
         


### PR DESCRIPTION
## Summary
- support selecting warehouse when creating/updating a product
- show warehouses in create/edit views and validate on client side
- sync warehouse stock via pivot table
- adjust layout classes to use `col-md-12`

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564c5dee548327be74a385fb26769e