### PR TITLE
Add vendor navbar icon CSS

### DIFF
--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -35,6 +35,12 @@
     .bi {
         font-size: 20px;
     }
+    .scrollbar .nav-icon i,
+    #navbar-nav .nav-icon i {
+        font-size: 20px !important;
+        line-height: 1;
+        vertical-align: middle;
+    }
     /* Preloader styles */
     #preloader {
         position: fixed;


### PR DESCRIPTION
## Summary
- tweak vendor navbar icon styles so icons look centered and sized consistently

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f8237321c83278a36f962d579b02f