### PR TITLE
Remove stock and warehouse fields from vendor product edit

### DIFF
--- a/app/Http/Controllers/Vendor/VendorProductController.php
+++ b/app/Http/Controllers/Vendor/VendorProductController.php
@@ -201,7 +201,6 @@ class VendorProductController extends Controller
             $product->price = $request->price;
             $product->unit = $unit;
             $product->min_order_qty = $request->min_order_qty ?? 1;
-            $product->stock_quantity = $request->stock_quantity ?? 0;
             $product->hsn_code = $hsn_code;
             $product->gst_rate = $request->gst_rate;
             $product->status = 'pending';
@@ -279,7 +278,6 @@ class VendorProductController extends Controller
         $product->price = $request->price;
         $product->unit = $request->unit;
         $product->min_order_qty = $request->min_order_qty ?? 1;
-        $product->stock_quantity = $request->stock_quantity ?? 0;
         $product->hsn_code = $request->hsn_code;
         $product->gst_rate = $request->gst_rate;
 
@@ -303,7 +301,6 @@ class VendorProductController extends Controller
                 'price' => 'required|numeric|min:0',
                 'slug' => 'nullable|string|unique:products,slug,' . $product->id,
                 'product_image' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
-                'warehouse_id' => 'required|exists:warehouses,id',
             ]);
 
             // Update product with validated data
@@ -315,7 +312,6 @@ class VendorProductController extends Controller
             $product->price = $validatedData['price'];
             $product->unit = $request->unit;
             $product->min_order_qty = $request->min_order_qty ?? 1;
-            $product->stock_quantity = $request->stock_quantity ?? 0;
             $product->hsn_code = $request->hsn_code;
             $product->gst_rate = $request->gst_rate;
 
@@ -325,19 +321,6 @@ class VendorProductController extends Controller
             }
 
             $product->save();
-
-            $warehouse = Warehouse::where('id', $request->warehouse_id)
-                ->where('vendor_id', Auth::id())
-                ->first();
-
-            if ($warehouse) {
-                WarehouseProduct::updateOrCreate([
-                    'warehouse_id' => $warehouse->id,
-                    'product_id' => $product->id,
-                ], [
-                    'quantity' => $product->stock_quantity,
-                ]);
-            }
 
             if ($request->ajax()) {
                 return response()->json([

--- a/resources/views/vendor/products/edit.blade.php
+++ b/resources/views/vendor/products/edit.blade.php
@@ -122,23 +122,7 @@
                             
                         </div>
 
-                        {{-- Stock Quantity --}}
-                        <div class="col-md-4">
-                            <label for="stock_quantity" class="form-label">Stock Quantity <span class="text-danger">*</span></label>
-                            <input type="number" name="stock_quantity" id="stock_quantity" class="form-control" placeholder="0" min="0" value="{{ old('stock_quantity', $product->stock_quantity) }}" required />
-
-                        </div>
-
-                        {{-- Warehouse --}}
-                        <div class="col-md-4">
-                            <label for="warehouse_id" class="form-label">Warehouse <span class="text-danger">*</span></label>
-                            <select name="warehouse_id" id="warehouse_id" class="form-select">
-                                <option value="">-- Select Warehouse --</option>
-                                @foreach($warehouses as $warehouse)
-                                    <option value="{{ $warehouse->id }}" {{ old('warehouse_id', $product->warehouses->first()->id ?? '') == $warehouse->id ? 'selected' : '' }}>{{ $warehouse->name }}</option>
-                                @endforeach
-                            </select>
-                        </div>
+                        {{-- Stock Quantity and Warehouse fields removed as per requirements --}}
 
                         {{-- HSN Code --}}
                         <div class="col-md-4">
@@ -305,27 +289,7 @@ $(document).ready(function () {
             isValid = false;
         }
         
-        // Validate stock quantity
-        const stockQty = parseInt($('#stock_quantity').val());
-        if (!$('#stock_quantity').val() || isNaN(stockQty)) {
-            $('#stock_quantity').addClass('is-invalid');
-            $('#stock_quantity').after('<span class="error error-message">Please enter a valid stock quantity</span>');
-            toastr.error('Please enter a valid stock quantity');
-            isValid = false;
-        } else if (stockQty < 0) {
-            $('#stock_quantity').addClass('is-invalid');
-            $('#stock_quantity').after('<span class="error error-message">Stock quantity cannot be negative</span>');
-            toastr.error('Stock quantity cannot be negative');
-            isValid = false;
-        }
-
-        // Validate warehouse
-        if (!$('#warehouse_id').val()) {
-            $('#warehouse_id').addClass('is-invalid');
-            $('#warehouse_id').after('<span class="error error-message">Please select a warehouse</span>');
-            toastr.error('Please select a warehouse');
-            isValid = false;
-        }
+        // Stock quantity and warehouse validation removed
         
         // Validate GST rate
         const gstRate = parseFloat($('#gst_rate').val());


### PR DESCRIPTION
## Summary
- remove stock and warehouse fields from vendor product edit form and validation
- adjust VendorProductController `update()` to ignore removed fields

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f84f02a108327a5b23d605fceae39