### PR TITLE
Fix vendor inventory UI

### DIFF
--- a/resources/views/vendor/inventory/_inventory_table.blade.php
+++ b/resources/views/vendor/inventory/_inventory_table.blade.php
@@ -21,9 +21,11 @@
     <td><input type="number" class="form-control form-control-sm stock-input-in" value="0" min="0"></td>
     <td><input type="number" class="form-control form-control-sm stock-input-out" value="0" min="0"></td>
     <td>{{ \Carbon\Carbon::parse($product->updated_at)->format('d-m-Y') }}</td>
-    <td>
-        <button class="btn btn-sm btn-primary update-stock" data-id="{{ $product->id }}"><i class="bi bi-save"></i> Update</button>
-        <button class="btn btn-sm btn-info view-stock-log" data-id="{{ $product->id }}"><i class="bi bi-clock-history"></i> Stock Log</button>
+    <td class="action-buttons">
+        <div class="d-inline-flex gap-1">
+            <button class="btn btn-sm btn-primary update-stock" data-id="{{ $product->id }}"><i class="bi bi-save"></i> Update</button>
+            <button class="btn btn-sm btn-info view-stock-log" data-id="{{ $product->id }}"><i class="bi bi-clock-history"></i> Stock Log</button>
+        </div>
     </td>
 </tr>
 @empty

--- a/resources/views/vendor/inventory/index.blade.php
+++ b/resources/views/vendor/inventory/index.blade.php
@@ -5,6 +5,10 @@
     #inventory-table tfoot ul.pagination {
         justify-content: flex-end;
     }
+    td.action-buttons > div {
+        display: inline-flex;
+        gap: .25rem;
+    }
 </style>
 @endpush
 @section('content')
@@ -126,8 +130,13 @@ $(document).ready(function(){
         });
     }
 
-    $('#search').on('click', function(){ fetchInventoryData(1); });
-    $('#reset').on('click', function(){ $('#filter-form').trigger('reset'); fetchInventoryData(1); });
+    $('#search').on('click', function(){
+        fetchInventoryData(1);
+    });
+    $('#reset').on('click', function(){
+        $('#filter-form').find('input, select').val('');
+        fetchInventoryData(1);
+    });
     $(document).on('click', '#inventory-table-foot-content a.page-link', function(e){
         e.preventDefault();
         const url = $(this).attr('href');


### PR DESCRIPTION
## Summary
- display action buttons inline with spacing
- ensure inventory filter reset clears inputs
- tweak vendor inventory page styles for action buttons

## Testing
- `composer install` *(fails: ext-dom missing)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6862c970622c832782b43e3fa51faa6b