### PR TITLE
Update stock logs to open as new page

### DIFF
--- a/app/Http/Controllers/Vendor/VendorInventoryController.php
+++ b/app/Http/Controllers/Vendor/VendorInventoryController.php
@@ -157,15 +157,19 @@ class VendorInventoryController extends Controller
     }
 
     /**
-     * Fetch stock logs for a product via AJAX
+     * Display stock logs for a product
      */
     public function stockLogs(Request $request, $id)
     {
         $logs = StockLog::with('user')
             ->where('product_id', $id)
             ->orderBy('created_at', 'desc')
-            ->paginate(10);
+            ->paginate($request->input('per_page', 10));
 
-        return view('vendor.inventory._stock_logs', compact('logs'));
+        if ($request->ajax()) {
+            return view('vendor.inventory._stock_logs', compact('logs'));
+        }
+
+        return view('vendor.inventory.logs', compact('logs'));
     }
 }

--- a/resources/views/vendor/inventory/_inventory_table.blade.php
+++ b/resources/views/vendor/inventory/_inventory_table.blade.php
@@ -24,7 +24,9 @@
     <td class="action-buttons">
         <div class="d-inline-flex gap-1">
             <button class="btn btn-sm btn-primary update-stock" data-id="{{ $product->id }}"><i class="bi bi-save"></i> Update</button>
-            <button class="btn btn-sm btn-info view-stock-log" data-id="{{ $product->id }}"><i class="bi bi-clock-history"></i> Stock Log</button>
+            <a href="{{ route('vendor.inventory.logs', $product->id) }}" class="btn btn-sm btn-info">
+                <i class="bi bi-clock-history"></i> Stock Log
+            </a>
         </div>
     </td>
 </tr>

--- a/resources/views/vendor/inventory/index.blade.php
+++ b/resources/views/vendor/inventory/index.blade.php
@@ -78,28 +78,6 @@
         </div>
 </div>
 </div>
-<!-- Stock Log Modal -->
-<div class="modal fade" id="stockLogModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Stock Logs</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body" id="stockLogModalBody">
-                <div class="row">
-                    <div class="col-md-12">
-                        <div class="card">
-                            <div class="card-body" id="stock-log-content">
-                                <!-- Logs will load here -->
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 <script>
 $(document).ready(function(){
     fetchInventoryData(1);
@@ -226,28 +204,6 @@ $(document).ready(function(){
         });
     });
 
-    $(document).on('click','.view-stock-log',function(){
-        const id=$(this).data('id');
-        $('#stockLogModal').data('product-id', id).modal('show');
-        fetchStockLogs(id,1);
-    });
-
-    $(document).on('click','#stock-log-content a.page-link',function(e){
-        e.preventDefault();
-        const page=new URL($(this).attr('href')).searchParams.get('page');
-        const id=$('#stockLogModal').data('product-id');
-        fetchStockLogs(id,page);
-    });
-
-    function fetchStockLogs(id,page){
-        $('#stock-log-content').html('<div class="text-center p-3"><div class="spinner-border" role="status"></div></div>');
-        $.ajax({
-            url:'{{ url('vendor/inventory') }}/'+id+'/logs',
-            data:{ page: page },
-            success:function(res){ $('#stock-log-content').html(res); },
-            error:function(){ $('#stock-log-content').html('<p class="text-danger text-center">Error loading logs.</p>'); }
-        });
-    }
 });
 </script>
 @endsection

--- a/resources/views/vendor/inventory/logs.blade.php
+++ b/resources/views/vendor/inventory/logs.blade.php
@@ -1,0 +1,29 @@
+@extends('vendor.layouts.app')
+@section('title', 'Stock Logs | Deal24hours')
+
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">Stock Logs</h4>
+                <a href="{{ route('vendor.inventory.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back</a>
+            </div>
+            <div class="card-body" id="stock-log-page-content">
+                @include('vendor.inventory._stock_logs', ['logs' => $logs])
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(document).on('change', '#perPage', function(){
+    const url = new URL(window.location.href);
+    url.searchParams.set('per_page', $(this).val());
+    url.searchParams.set('page', 1);
+    window.location.href = url.toString();
+});
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- display vendor stock logs on a dedicated page
- update inventory table to link to the new page
- remove modal-based log viewer
- support ajax/regular responses in controller

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cc8ef4848327859a963a4882c4f3