### PR TITLE
Add product name on Stock Logs & AJAX reload

### DIFF
--- a/resources/views/vendor/inventory/_stock_logs.blade.php
+++ b/resources/views/vendor/inventory/_stock_logs.blade.php
@@ -3,6 +3,7 @@
         <thead class="bg-light-subtle">
             <tr>
                 <th>#</th>
+                <th>Product</th>
                 <th>Old Qty</th>
                 <th>New Qty</th>
                 <th>User</th>
@@ -13,6 +14,7 @@
             @forelse($logs as $log)
                 <tr>
                     <td>{{ ($logs->currentPage() - 1) * $logs->perPage() + $loop->iteration }}</td>
+                    <td>{{ $log->product->product_name }}</td>
                     <td>{{ $log->old_quantity }}</td>
                     <td>{{ $log->new_quantity }}</td>
                     <td>{{ $log->user->name }}</td>
@@ -20,7 +22,7 @@
                 </tr>
             @empty
                 <tr>
-                    <td colspan="5" class="text-center">No records found.</td>
+                    <td colspan="6" class="text-center">No records found.</td>
                 </tr>
             @endforelse
         </tbody>

--- a/resources/views/vendor/inventory/logs.blade.php
+++ b/resources/views/vendor/inventory/logs.blade.php
@@ -6,7 +6,7 @@
     <div class="col-md-12">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center gap-1">
-                <h4 class="card-title flex-grow-1">Stock Logs</h4>
+                <h4 class="card-title flex-grow-1">Stock Logs - {{ $product->product_name }}</h4>
                 <a href="{{ route('vendor.inventory.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back</a>
             </div>
             <div class="card-body" id="stock-log-page-content">
@@ -19,11 +19,39 @@
 
 @push('scripts')
 <script>
-$(document).on('change', '#perPage', function(){
-    const url = new URL(window.location.href);
-    url.searchParams.set('per_page', $(this).val());
-    url.searchParams.set('page', 1);
-    window.location.href = url.toString();
+$(document).ready(function(){
+    let currentAjaxRequest = null;
+    function fetchLogs(page = 1, perPage = null){
+        if(currentAjaxRequest && currentAjaxRequest.readyState !== 4){
+            currentAjaxRequest.abort();
+        }
+        $('#stock-log-page-content').html('<div class="text-center"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div></div>');
+        perPage = perPage || $('#perPage').val() || 10;
+        currentAjaxRequest = $.ajax({
+            url: '{{ route('vendor.inventory.logs', $product->id) }}',
+            method: 'GET',
+            data: { page: page, per_page: perPage },
+            success: function(res){
+                $('#stock-log-page-content').html(res);
+            },
+            error: function(xhr){
+                if(xhr.statusText === 'abort'){ return; }
+                $('#stock-log-page-content').html('<div class="text-center text-danger">Error loading logs.</div>');
+            },
+            complete: function(){ currentAjaxRequest = null; }
+        });
+    }
+
+    $(document).on('click', '#stock-log-page-content .pagination a.page-link', function(e){
+        e.preventDefault();
+        const url = $(this).attr('href');
+        const page = new URL(url).searchParams.get('page');
+        if(page){ fetchLogs(page); }
+    });
+
+    $(document).on('change', '#perPage', function(){
+        fetchLogs(1, $(this).val());
+    });
 });
 </script>
 @endpush


### PR DESCRIPTION
## Summary
- display product name in the stock logs header and rows
- validate log requests
- reload log table via AJAX

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6862cef6b9f483278b690ab3649d29c0