### PR TITLE
Add Banner module

### DIFF
--- a/app/Http/Controllers/Admin/BannerController.php
+++ b/app/Http/Controllers/Admin/BannerController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Banner;
+use Illuminate\Http\Request;
+use Yajra\DataTables\DataTables;
+use Illuminate\Support\Facades\Validator;
+use Carbon\Carbon;
+
+class BannerController extends Controller
+{
+    public function index()
+    {
+        return view('admin.banners.index');
+    }
+
+    public function getBanners(Request $request)
+    {
+        $banners = Banner::query()->latest();
+
+        return DataTables::of($banners)
+            ->addIndexColumn()
+            ->editColumn('status', function ($banner) {
+                $status = $banner->status == 1 ? 'active' : 'inactive';
+                $class = $banner->status == 1 ? 'badge border border-success text-success px-2 py-1 fs-13' : 'badge border border-danger text-danger px-2 py-1 fs-13';
+                return '<span class="'.$class.'">'.ucfirst($status).'</span>';
+            })
+            ->addColumn('action', function ($banner) {
+                return '<a href="'.route('admin.banners.edit', $banner->id).'" class="btn btn-soft-primary btn-sm"><i class="bi bi-pencil"></i></a>';
+            })
+            ->rawColumns(['status','action'])
+            ->make(true);
+    }
+
+    public function create()
+    {
+        return view('admin.banners.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'banner_img' => 'required|string|max:255',
+            'banner_link' => 'nullable|url',
+            'banner_start_date' => 'nullable|date_format:d-m-Y',
+            'banner_end_date' => 'nullable|date_format:d-m-Y|after_or_equal:banner_start_date',
+            'status' => 'required|in:1,2',
+            'banner_type' => 'required|integer'
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json(['status' => 0, 'errors' => $validator->errors()], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $data = $validator->validated();
+        if (!empty($data['banner_start_date'])) {
+            $data['banner_start_date'] = Carbon::createFromFormat('d-m-Y', $data['banner_start_date'])->format('Y-m-d');
+        }
+        if (!empty($data['banner_end_date'])) {
+            $data['banner_end_date'] = Carbon::createFromFormat('d-m-Y', $data['banner_end_date'])->format('Y-m-d');
+        }
+
+        Banner::create($data);
+
+        if ($request->ajax()) {
+            return response()->json([
+                'status' => 1,
+                'message' => 'Banner added successfully!',
+                'redirect' => route('admin.banners.index'),
+            ]);
+        }
+    }
+
+    public function edit($id)
+    {
+        $banner = Banner::findOrFail($id);
+        return view('admin.banners.edit', compact('banner'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $banner = Banner::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'banner_img' => 'required|string|max:255',
+            'banner_link' => 'nullable|url',
+            'banner_start_date' => 'nullable|date_format:d-m-Y',
+            'banner_end_date' => 'nullable|date_format:d-m-Y|after_or_equal:banner_start_date',
+            'status' => 'required|in:1,2',
+            'banner_type' => 'required|integer'
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json(['status' => 0, 'errors' => $validator->errors()], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $data = $validator->validated();
+        if (!empty($data['banner_start_date'])) {
+            $data['banner_start_date'] = Carbon::createFromFormat('d-m-Y', $data['banner_start_date'])->format('Y-m-d');
+        }
+        if (!empty($data['banner_end_date'])) {
+            $data['banner_end_date'] = Carbon::createFromFormat('d-m-Y', $data['banner_end_date'])->format('Y-m-d');
+        }
+
+        $banner->update($data);
+
+        if ($request->ajax()) {
+            return response()->json([
+                'status' => 1,
+                'message' => 'Banner updated successfully!',
+                'redirect' => route('admin.banners.index'),
+            ]);
+        }
+    }
+}

--- a/app/Models/Banner.php
+++ b/app/Models/Banner.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\LogOptions;
+
+class Banner extends Model
+{
+    use LogsActivity;
+
+    protected $fillable = [
+        'banner_img',
+        'banner_link',
+        'banner_start_date',
+        'banner_end_date',
+        'status',
+        'banner_type',
+    ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()->logFillable()->logOnlyDirty()->dontSubmitEmptyLogs();
+    }
+}

--- a/database/migrations/2025_06_20_000000_create_banners_table.php
+++ b/database/migrations/2025_06_20_000000_create_banners_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('banners', function (Blueprint $table) {
+            $table->id();
+            $table->string('banner_img');
+            $table->string('banner_link')->nullable();
+            $table->date('banner_start_date')->nullable();
+            $table->date('banner_end_date')->nullable();
+            $table->tinyInteger('status')->default(1);
+            $table->tinyInteger('banner_type')->default(1); // 1->home slider
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('banners');
+    }
+};

--- a/resources/views/admin/banners/create.blade.php
+++ b/resources/views/admin/banners/create.blade.php
@@ -1,0 +1,112 @@
+@extends('admin.layouts.app')
+@section('title', 'Add Banner | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">Add Banner</h4>
+                <a href="{{ route('admin.banners.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back to List</a>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.banners.store') }}" method="POST" id="bannerForm">
+                    @csrf
+                    <div class="row gy-3">
+                        <div class="col-md-12">
+                            <label class="form-label">Image Path <span class="text-danger">*</span></label>
+                            <input type="text" name="banner_img" id="banner_img" class="form-control" placeholder="/path/to/image.jpg">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Link</label>
+                            <input type="url" name="banner_link" id="banner_link" class="form-control" placeholder="https://example.com">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Start Date</label>
+                            <input type="text" name="banner_start_date" id="banner_start_date" class="form-control" placeholder="dd-mm-yyyy">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">End Date</label>
+                            <input type="text" name="banner_end_date" id="banner_end_date" class="form-control" placeholder="dd-mm-yyyy">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Status</label>
+                            <select name="status" id="status" class="form-select">
+                                <option value="1">Active</option>
+                                <option value="2">Inactive</option>
+                            </select>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Banner Type</label>
+                            <select name="banner_type" id="banner_type" class="form-select">
+                                <option value="1" selected>Home Slider</option>
+                            </select>
+                        </div>
+                        <div class="col-12 text-end mt-3">
+                            <button type="submit" class="btn btn-primary">Save Banner</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('.is-invalid').removeClass('is-invalid');
+        const dateRegex = /^\d{2}-\d{2}-\d{4}$/;
+        if(!$('#banner_img').val()){
+            $('#banner_img').addClass('is-invalid');
+            ok = false;
+        }
+        if($('#banner_start_date').val() && !dateRegex.test($('#banner_start_date').val())){
+            $('#banner_start_date').addClass('is-invalid');
+            ok = false;
+        }
+        if($('#banner_end_date').val() && !dateRegex.test($('#banner_end_date').val())){
+            $('#banner_end_date').addClass('is-invalid');
+            ok = false;
+        }
+        return ok;
+    }
+    $('#bannerForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var form = $(this);
+        $.ajax({
+            url: form.attr('action'),
+            type: 'POST',
+            data: form.serialize(),
+            beforeSend:function(){
+                form.find('button[type="submit"]').prop('disabled',true).html('<span class="spinner-border spinner-border-sm"></span> Saving...');
+            },
+            success:function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(()=>{ window.location.href = res.redirect; },1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error:function(xhr){
+                if(xhr.status===422){
+                    $.each(xhr.responseJSON.errors,function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete:function(){
+                form.find('button[type="submit"]').prop('disabled',false).html('Save Banner');
+            }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/banners/edit.blade.php
+++ b/resources/views/admin/banners/edit.blade.php
@@ -1,0 +1,113 @@
+@extends('admin.layouts.app')
+@section('title', 'Edit Banner | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">Edit Banner</h4>
+                <a href="{{ route('admin.banners.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back to List</a>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.banners.update', $banner->id) }}" method="POST" id="bannerForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="row gy-3">
+                        <div class="col-md-12">
+                            <label class="form-label">Image Path <span class="text-danger">*</span></label>
+                            <input type="text" name="banner_img" id="banner_img" class="form-control" value="{{ old('banner_img', $banner->banner_img) }}">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Link</label>
+                            <input type="url" name="banner_link" id="banner_link" class="form-control" value="{{ old('banner_link', $banner->banner_link) }}">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Start Date</label>
+                            <input type="text" name="banner_start_date" id="banner_start_date" class="form-control" value="{{ old('banner_start_date', optional($banner->banner_start_date)->format('d-m-Y')) }}" placeholder="dd-mm-yyyy">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">End Date</label>
+                            <input type="text" name="banner_end_date" id="banner_end_date" class="form-control" value="{{ old('banner_end_date', optional($banner->banner_end_date)->format('d-m-Y')) }}" placeholder="dd-mm-yyyy">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Status</label>
+                            <select name="status" id="status" class="form-select">
+                                <option value="1" {{ old('status', $banner->status) == 1 ? 'selected' : '' }}>Active</option>
+                                <option value="2" {{ old('status', $banner->status) == 2 ? 'selected' : '' }}>Inactive</option>
+                            </select>
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">Banner Type</label>
+                            <select name="banner_type" id="banner_type" class="form-select">
+                                <option value="1" {{ old('banner_type', $banner->banner_type) == 1 ? 'selected' : '' }}>Home Slider</option>
+                            </select>
+                        </div>
+                        <div class="col-12 text-end mt-3">
+                            <button type="submit" class="btn btn-primary">Update Banner</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    function validateForm(){
+        let ok = true;
+        $('.is-invalid').removeClass('is-invalid');
+        const dateRegex = /^\d{2}-\d{2}-\d{4}$/;
+        if(!$('#banner_img').val()){
+            $('#banner_img').addClass('is-invalid');
+            ok = false;
+        }
+        if($('#banner_start_date').val() && !dateRegex.test($('#banner_start_date').val())){
+            $('#banner_start_date').addClass('is-invalid');
+            ok = false;
+        }
+        if($('#banner_end_date').val() && !dateRegex.test($('#banner_end_date').val())){
+            $('#banner_end_date').addClass('is-invalid');
+            ok = false;
+        }
+        return ok;
+    }
+    $('#bannerForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()){
+            toastr.error('Please fix the validation errors.');
+            return;
+        }
+        var form = $(this);
+        $.ajax({
+            url: form.attr('action'),
+            type: 'POST',
+            data: form.serialize(),
+            beforeSend:function(){
+                form.find('button[type="submit"]').prop('disabled',true).html('<span class="spinner-border spinner-border-sm"></span> Updating...');
+            },
+            success:function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    setTimeout(()=>{ window.location.href = res.redirect; },1000);
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error:function(xhr){
+                if(xhr.status===422){
+                    $.each(xhr.responseJSON.errors,function(k,v){
+                        $('[name="'+k+'"]').addClass('is-invalid');
+                        toastr.error(v[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'Something went wrong');
+                }
+            },
+            complete:function(){
+                form.find('button[type="submit"]').prop('disabled',false).html('Update Banner');
+            }
+        });
+    });
+});
+</script>
+@endsection

--- a/resources/views/admin/banners/index.blade.php
+++ b/resources/views/admin/banners/index.blade.php
@@ -1,0 +1,54 @@
+@extends('admin.layouts.app')
+@section('title', 'Banners | Deal24hours')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center gap-1">
+                <h4 class="card-title flex-grow-1">All Banners</h4>
+                <a href="{{ route('admin.banners.create') }}" class="btn btn-sm btn-primary">
+                    <i class="bi bi-plus-lg"></i> Add Banner
+                </a>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0 table-striped table-centered" id="banners-table" style="width:100%">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>#</th>
+                                <th>Image</th>
+                                <th>Link</th>
+                                <th>Start Date</th>
+                                <th>End Date</th>
+                                <th>Status</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.datatables.net/1.13.5/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.5/js/dataTables.bootstrap5.min.js"></script>
+<script>
+$(function(){
+    const table = $('#banners-table').DataTable({
+        processing:true,
+        serverSide:true,
+        ajax:'{{ route('admin.banners.data') }}',
+        columns:[
+            {data:'id', name:'id'},
+            {data:'banner_img', name:'banner_img', orderable:false, searchable:false},
+            {data:'banner_link', name:'banner_link', orderable:false, searchable:false},
+            {data:'banner_start_date', name:'banner_start_date', orderable:false, searchable:false},
+            {data:'banner_end_date', name:'banner_end_date', orderable:false, searchable:false},
+            {data:'status', name:'status', orderable:false, searchable:false},
+            {data:'action', name:'action', orderable:false, searchable:false}
+        ]
+    });
+});
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,15 @@ Route::middleware(['auth'])->group(function () {
         Route::get('get-subcategories/{parentId}', [CategoryController::class, 'getSubcategories'])->name('get-subcategories');
     });
 
+    Route::prefix('admin/banners')->name('admin.banners.')->group(function () {
+        Route::get('list', [App\Http\Controllers\Admin\BannerController::class, 'index'])->name('index');
+        Route::get('data', [App\Http\Controllers\Admin\BannerController::class, 'getBanners'])->name('data');
+        Route::get('create', [App\Http\Controllers\Admin\BannerController::class, 'create'])->name('create');
+        Route::post('store', [App\Http\Controllers\Admin\BannerController::class, 'store'])->name('store');
+        Route::get('edit/{id}', [App\Http\Controllers\Admin\BannerController::class, 'edit'])->name('edit');
+        Route::put('update/{id}', [App\Http\Controllers\Admin\BannerController::class, 'update'])->name('update');
+    });
+
     Route::prefix('admin/vendors')->name('admin.vendors.')->group(function () {
         Route::get('list', [VendorController::class, 'index'])->name('index');
         Route::get('data', [VendorController::class, 'getVendors'])->name('data');


### PR DESCRIPTION
## Summary
- create banners table migration
- add Banner model and controller
- register admin routes for Banner CRUD
- implement banner listing with DataTables
- add AJAX forms for create and edit with client-side validation

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686811724c2483279167f678ad458066