### PR TITLE
Add AJAX-based banner list

### DIFF
--- a/app/Http/Controllers/Admin/BannerController.php
+++ b/app/Http/Controllers/Admin/BannerController.php
@@ -34,6 +34,25 @@ class BannerController extends Controller
             ->make(true);
     }
 
+    /**
+     * Render banners table for AJAX pagination similar to other lists.
+     */
+    public function renderBannersTable(Request $request)
+    {
+        $perPage = $request->input('per_page', 10);
+        $page    = $request->input('page', 1);
+
+        $query = Banner::query()
+            ->when($request->status !== null && $request->status !== '', function ($q) use ($request) {
+                $q->where('status', (int) $request->status);
+            })
+            ->orderBy('created_at', 'desc');
+
+        $banners = $query->paginate($perPage, ['*'], 'page', $page);
+
+        return view('admin.banners._banners_table', compact('banners'));
+    }
+
     public function create()
     {
         return view('admin.banners.create');

--- a/resources/views/admin/banners/_banners_table.blade.php
+++ b/resources/views/admin/banners/_banners_table.blade.php
@@ -1,0 +1,38 @@
+<tbody>
+    @forelse($banners as $banner)
+        <tr>
+            <td>{{ $loop->iteration + ($banners->currentPage() - 1) * $banners->perPage() }}</td>
+            <td>
+                @if($banner->banner_img)
+                    <img src="{{ asset($banner->banner_img) }}" alt="Banner" style="max-height:50px;">
+                @else
+                    N/A
+                @endif
+            </td>
+            <td>{{ $banner->banner_link ?? '-' }}</td>
+            <td>{{ $banner->banner_start_date ? \Carbon\Carbon::parse($banner->banner_start_date)->format('d-m-Y') : '-' }}</td>
+            <td>{{ $banner->banner_end_date ? \Carbon\Carbon::parse($banner->banner_end_date)->format('d-m-Y') : '-' }}</td>
+            <td>
+                @php
+                    $status = $banner->status == 1 ? 'active' : 'inactive';
+                    $class  = $banner->status == 1 ? 'badge border border-success text-success px-2 py-1 fs-13' : 'badge border border-danger text-danger px-2 py-1 fs-13';
+                @endphp
+                <span class="{{ $class }}">{{ ucfirst($status) }}</span>
+            </td>
+            <td>
+                <a href="{{ route('admin.banners.edit', $banner->id) }}" class="btn btn-soft-primary btn-sm">
+                    <i class="bi bi-pencil"></i>
+                </a>
+            </td>
+        </tr>
+    @empty
+        <tr>
+            <td colspan="7" class="text-center">No banners found.</td>
+        </tr>
+    @endforelse
+</tbody>
+<tfoot>
+    <tr>
+        <x-custom-pagination :paginator="$banners" />
+    </tr>
+</tfoot>

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,6 +64,7 @@ Route::middleware(['auth'])->group(function () {
     Route::prefix('admin/banners')->name('admin.banners.')->group(function () {
         Route::get('list', [App\Http\Controllers\Admin\BannerController::class, 'index'])->name('index');
         Route::get('data', [App\Http\Controllers\Admin\BannerController::class, 'getBanners'])->name('data');
+        Route::get('render-table', [App\Http\Controllers\Admin\BannerController::class, 'renderBannersTable'])->name('render-table');
         Route::get('create', [App\Http\Controllers\Admin\BannerController::class, 'create'])->name('create');
         Route::post('store', [App\Http\Controllers\Admin\BannerController::class, 'store'])->name('store');
         Route::get('edit/{id}', [App\Http\Controllers\Admin\BannerController::class, 'edit'])->name('edit');


### PR DESCRIPTION
## Summary
- implement AJAX table fetch for banners
- add route to render banner table
- show banner index with filters and AJAX pagination
- include banner table partial for rendering

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686816840538832797375555c5258f3a