### PR TITLE
Enable file uploads for banners

### DIFF
--- a/app/Http/Controllers/Admin/BannerController.php
+++ b/app/Http/Controllers/Admin/BannerController.php
@@ -61,7 +61,7 @@ class BannerController extends Controller
     public function store(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'banner_img' => 'required|string|max:255',
+            'banner_img' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
             'banner_link' => 'nullable|url',
             'banner_start_date' => 'nullable|date_format:d-m-Y',
             'banner_end_date' => 'nullable|date_format:d-m-Y|after_or_equal:banner_start_date',
@@ -77,6 +77,9 @@ class BannerController extends Controller
         }
 
         $data = $validator->validated();
+        if ($request->hasFile('banner_img')) {
+            $data['banner_img'] = $request->file('banner_img')->store('uploads/banners', 'public');
+        }
         if (!empty($data['banner_start_date'])) {
             $data['banner_start_date'] = Carbon::createFromFormat('d-m-Y', $data['banner_start_date'])->format('Y-m-d');
         }
@@ -106,7 +109,7 @@ class BannerController extends Controller
         $banner = Banner::findOrFail($id);
 
         $validator = Validator::make($request->all(), [
-            'banner_img' => 'required|string|max:255',
+            'banner_img' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
             'banner_link' => 'nullable|url',
             'banner_start_date' => 'nullable|date_format:d-m-Y',
             'banner_end_date' => 'nullable|date_format:d-m-Y|after_or_equal:banner_start_date',
@@ -122,6 +125,9 @@ class BannerController extends Controller
         }
 
         $data = $validator->validated();
+        if ($request->hasFile('banner_img')) {
+            $data['banner_img'] = $request->file('banner_img')->store('uploads/banners', 'public');
+        }
         if (!empty($data['banner_start_date'])) {
             $data['banner_start_date'] = Carbon::createFromFormat('d-m-Y', $data['banner_start_date'])->format('Y-m-d');
         }

--- a/resources/views/admin/banners/_banners_table.blade.php
+++ b/resources/views/admin/banners/_banners_table.blade.php
@@ -4,7 +4,7 @@
             <td>{{ $loop->iteration + ($banners->currentPage() - 1) * $banners->perPage() }}</td>
             <td>
                 @if($banner->banner_img)
-                    <img src="{{ asset($banner->banner_img) }}" alt="Banner" style="max-height:50px;">
+                    <img src="{{ asset('storage/'.$banner->banner_img) }}" alt="Banner" style="max-height:50px;">
                 @else
                     N/A
                 @endif

--- a/resources/views/admin/banners/create.blade.php
+++ b/resources/views/admin/banners/create.blade.php
@@ -9,12 +9,13 @@
                 <a href="{{ route('admin.banners.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back to List</a>
             </div>
             <div class="card-body">
-                <form action="{{ route('admin.banners.store') }}" method="POST" id="bannerForm">
+                <form action="{{ route('admin.banners.store') }}" method="POST" id="bannerForm" enctype="multipart/form-data">
                     @csrf
                     <div class="row gy-3">
                         <div class="col-md-12">
-                            <label class="form-label">Image Path <span class="text-danger">*</span></label>
-                            <input type="text" name="banner_img" id="banner_img" class="form-control" placeholder="/path/to/image.jpg">
+                            <label class="form-label">Banner Image <span class="text-danger">*</span></label>
+                            <input type="file" name="banner_img" id="banner_img" class="form-control" accept="image/*">
+                            <small class="text-muted">Max file size: 2MB</small>
                         </div>
                         <div class="col-md-12">
                             <label class="form-label">Link</label>
@@ -56,9 +57,18 @@ $(function(){
         let ok = true;
         $('.is-invalid').removeClass('is-invalid');
         const dateRegex = /^\d{2}-\d{2}-\d{4}$/;
-        if(!$('#banner_img').val()){
+        const fileInput = $('#banner_img')[0];
+        if(fileInput.files.length === 0){
             $('#banner_img').addClass('is-invalid');
             ok = false;
+        }else{
+            const file = fileInput.files[0];
+            const validTypes = ['image/jpeg','image/png','image/jpg','image/gif'];
+            const maxSize = 2 * 1024 * 1024; // 2MB
+            if(!validTypes.includes(file.type) || file.size > maxSize){
+                $('#banner_img').addClass('is-invalid');
+                ok = false;
+            }
         }
         if($('#banner_start_date').val() && !dateRegex.test($('#banner_start_date').val())){
             $('#banner_start_date').addClass('is-invalid');
@@ -77,10 +87,13 @@ $(function(){
             return;
         }
         var form = $(this);
+        var formData = new FormData(this);
         $.ajax({
             url: form.attr('action'),
             type: 'POST',
-            data: form.serialize(),
+            data: formData,
+            processData:false,
+            contentType:false,
             beforeSend:function(){
                 form.find('button[type="submit"]').prop('disabled',true).html('<span class="spinner-border spinner-border-sm"></span> Saving...');
             },

--- a/resources/views/admin/banners/edit.blade.php
+++ b/resources/views/admin/banners/edit.blade.php
@@ -9,13 +9,19 @@
                 <a href="{{ route('admin.banners.index') }}" class="badge border border-secondary text-secondary px-2 py-1 fs-13">&larr; Back to List</a>
             </div>
             <div class="card-body">
-                <form action="{{ route('admin.banners.update', $banner->id) }}" method="POST" id="bannerForm">
+                <form action="{{ route('admin.banners.update', $banner->id) }}" method="POST" id="bannerForm" enctype="multipart/form-data">
                     @csrf
                     @method('PUT')
                     <div class="row gy-3">
                         <div class="col-md-12">
-                            <label class="form-label">Image Path <span class="text-danger">*</span></label>
-                            <input type="text" name="banner_img" id="banner_img" class="form-control" value="{{ old('banner_img', $banner->banner_img) }}">
+                            <label class="form-label">Banner Image <span class="text-danger">*</span></label>
+                            <input type="file" name="banner_img" id="banner_img" class="form-control" accept="image/*">
+                            <small class="text-muted">Max file size: 2MB</small>
+                            @if($banner->banner_img)
+                                <div class="mt-2">
+                                    <img src="{{ asset('storage/'.$banner->banner_img) }}" alt="Banner" style="max-height:60px;">
+                                </div>
+                            @endif
                         </div>
                         <div class="col-md-12">
                             <label class="form-label">Link</label>
@@ -57,9 +63,18 @@ $(function(){
         let ok = true;
         $('.is-invalid').removeClass('is-invalid');
         const dateRegex = /^\d{2}-\d{2}-\d{4}$/;
-        if(!$('#banner_img').val()){
+        const fileInput = $('#banner_img')[0];
+        if(fileInput.files.length === 0){
             $('#banner_img').addClass('is-invalid');
             ok = false;
+        }else{
+            const file = fileInput.files[0];
+            const validTypes = ['image/jpeg','image/png','image/jpg','image/gif'];
+            const maxSize = 2 * 1024 * 1024;
+            if(!validTypes.includes(file.type) || file.size > maxSize){
+                $('#banner_img').addClass('is-invalid');
+                ok = false;
+            }
         }
         if($('#banner_start_date').val() && !dateRegex.test($('#banner_start_date').val())){
             $('#banner_start_date').addClass('is-invalid');
@@ -78,10 +93,13 @@ $(function(){
             return;
         }
         var form = $(this);
+        var formData = new FormData(this);
         $.ajax({
             url: form.attr('action'),
             type: 'POST',
-            data: form.serialize(),
+            data: formData,
+            processData:false,
+            contentType:false,
             beforeSend:function(){
                 form.find('button[type="submit"]').prop('disabled',true).html('<span class="spinner-border spinner-border-sm"></span> Updating...');
             },


### PR DESCRIPTION
## Summary
- switch banner image path to file upload
- validate banner file uploads client-side and server-side
- handle file uploads in BannerController
- show banner images from storage

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686818c8628083278217a8a0f7369fac