### PR TITLE
Add date range fields to vendor subscriptions

### DIFF
--- a/app/Http/Controllers/Admin/VendorSubscriptionController.php
+++ b/app/Http/Controllers/Admin/VendorSubscriptionController.php
@@ -58,10 +58,12 @@ class VendorSubscriptionController extends Controller
     public function store(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'user_id'   => 'required|exists:users,id',
-            'plan_name' => 'required|exists:plans,name',
-            'duration'  => 'required|integer|min:1|max:24',
-            'status'    => 'required|in:active,expired',
+            'user_id'    => 'required|exists:users,id',
+            'plan_name'  => 'required|exists:plans,name',
+            'duration'   => 'required|integer|min:1|max:24',
+            'start_date' => 'required|date_format:d-m-Y',
+            'end_date'   => 'required|date_format:d-m-Y|after_or_equal:start_date',
+            'status'     => 'required|in:active,expired',
         ]);
 
         if ($validator->fails()) {
@@ -76,10 +78,8 @@ class VendorSubscriptionController extends Controller
 
         try {
             $data = $validator->validated();
-            $duration = (int) $data['duration'];
-            $start = Carbon::now();
-            $data['start_date'] = $start->toDateString();
-            $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
+            $data['start_date'] = Carbon::createFromFormat('d-m-Y', $data['start_date'])->format('Y-m-d');
+            $data['end_date'] = Carbon::createFromFormat('d-m-Y', $data['end_date'])->format('Y-m-d');
             unset($data['duration']);
             VendorSubscription::create($data);
             if ($request->ajax()) {
@@ -121,10 +121,12 @@ class VendorSubscriptionController extends Controller
         $subscription = VendorSubscription::findOrFail($id);
 
         $validator = Validator::make($request->all(), [
-            'user_id'   => 'required|exists:users,id',
-            'plan_name' => 'required|exists:plans,name',
-            'duration'  => 'required|integer|min:1|max:24',
-            'status'    => 'required|in:active,expired',
+            'user_id'    => 'required|exists:users,id',
+            'plan_name'  => 'required|exists:plans,name',
+            'duration'   => 'required|integer|min:1|max:24',
+            'start_date' => 'required|date_format:d-m-Y',
+            'end_date'   => 'required|date_format:d-m-Y|after_or_equal:start_date',
+            'status'     => 'required|in:active,expired',
         ]);
 
         if ($validator->fails()) {
@@ -139,10 +141,8 @@ class VendorSubscriptionController extends Controller
 
         try {
             $data = $validator->validated();
-            $duration = (int) $data['duration'];
-            $start = Carbon::now();
-            $data['start_date'] = $start->toDateString();
-            $data['end_date'] = $start->copy()->addMonths($duration)->toDateString();
+            $data['start_date'] = Carbon::createFromFormat('d-m-Y', $data['start_date'])->format('Y-m-d');
+            $data['end_date'] = Carbon::createFromFormat('d-m-Y', $data['end_date'])->format('Y-m-d');
             unset($data['duration']);
             $subscription->update($data);
             if ($request->ajax()) {

--- a/resources/views/admin/subscriptions/create.blade.php
+++ b/resources/views/admin/subscriptions/create.blade.php
@@ -35,6 +35,14 @@
                             </select>
                         </div>
                         <div class="col-md-6">
+                            <label class="form-label">Start Date <span class="text-danger">*</span></label>
+                            <input type="text" name="start_date" id="start_date" class="form-control date-picker" placeholder="dd-mm-yyyy" value="{{ old('start_date') }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">End Date <span class="text-danger">*</span></label>
+                            <input type="text" name="end_date" id="end_date" class="form-control date-picker" placeholder="dd-mm-yyyy" value="{{ old('end_date') }}">
+                        </div>
+                        <div class="col-md-6">
                             <label class="form-label">Status <span class="text-danger">*</span></label>
                             <select name="status" id="status" class="form-select">
                                 <option value="active">Active</option>
@@ -55,8 +63,12 @@
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
 $(function(){
+    flatpickr('#start_date', {dateFormat: 'd-m-Y'});
+    flatpickr('#end_date', {dateFormat: 'd-m-Y'});
+
     function validateForm(){
         let ok = true;
+        const dateRegex = /^\d{2}-\d{2}-\d{4}$/;
         $('#subscriptionForm').find('select, input').each(function(){
             if(!$(this).val()){
                 $(this).addClass('is-invalid');
@@ -65,6 +77,27 @@ $(function(){
                 $(this).removeClass('is-invalid');
             }
         });
+
+        if(!dateRegex.test($('#start_date').val())){
+            $('#start_date').addClass('is-invalid');
+            ok = false;
+        }
+        if(!dateRegex.test($('#end_date').val())){
+            $('#end_date').addClass('is-invalid');
+            ok = false;
+        }
+
+        if(ok){
+            const partsStart = $('#start_date').val().split('-');
+            const partsEnd = $('#end_date').val().split('-');
+            const start = new Date(partsStart[2], partsStart[1]-1, partsStart[0]);
+            const end = new Date(partsEnd[2], partsEnd[1]-1, partsEnd[0]);
+            if(start > end){
+                $('#end_date').addClass('is-invalid');
+                toastr.error('End Date must be after Start Date');
+                ok = false;
+            }
+        }
         return ok;
     }
     $('#subscriptionForm').on('submit', function(e){

--- a/resources/views/admin/subscriptions/edit.blade.php
+++ b/resources/views/admin/subscriptions/edit.blade.php
@@ -40,6 +40,14 @@
                             </select>
                         </div>
                         <div class="col-md-6">
+                            <label class="form-label">Start Date <span class="text-danger">*</span></label>
+                            <input type="text" name="start_date" id="start_date" class="form-control date-picker" value="{{ old('start_date', optional($subscription->start_date)->format('d-m-Y')) }}" placeholder="dd-mm-yyyy">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">End Date <span class="text-danger">*</span></label>
+                            <input type="text" name="end_date" id="end_date" class="form-control date-picker" value="{{ old('end_date', optional($subscription->end_date)->format('d-m-Y')) }}" placeholder="dd-mm-yyyy">
+                        </div>
+                        <div class="col-md-6">
                             <label class="form-label">Status <span class="text-danger">*</span></label>
                             <select name="status" id="status" class="form-select">
                                 <option value="active" {{ $subscription->status == 'active' ? 'selected' : '' }}>Active</option>
@@ -60,8 +68,12 @@
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
 $(function(){
+    flatpickr('#start_date', {dateFormat: 'd-m-Y'});
+    flatpickr('#end_date', {dateFormat: 'd-m-Y'});
+
     function validateForm(){
         let ok = true;
+        const dateRegex = /^\d{2}-\d{2}-\d{4}$/;
         $('#subscriptionForm').find('select, input').each(function(){
             if(!$(this).val()){
                 $(this).addClass('is-invalid');
@@ -70,6 +82,27 @@ $(function(){
                 $(this).removeClass('is-invalid');
             }
         });
+
+        if(!dateRegex.test($('#start_date').val())){
+            $('#start_date').addClass('is-invalid');
+            ok = false;
+        }
+        if(!dateRegex.test($('#end_date').val())){
+            $('#end_date').addClass('is-invalid');
+            ok = false;
+        }
+
+        if(ok){
+            const ps = $('#start_date').val().split('-');
+            const pe = $('#end_date').val().split('-');
+            const start = new Date(ps[2], ps[1]-1, ps[0]);
+            const end = new Date(pe[2], pe[1]-1, pe[0]);
+            if(start > end){
+                $('#end_date').addClass('is-invalid');
+                toastr.error('End Date must be after Start Date');
+                ok = false;
+            }
+        }
         return ok;
     }
     $('#subscriptionForm').on('submit', function(e){


### PR DESCRIPTION
## Summary
- support specifying start and end dates for vendor subscriptions
- validate the date range on the client and server
- show flatpickr date pickers in admin forms

## Testing
- `php --version` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681c6228548327bec463a09d72aebf