### PR TITLE
Fix date pickers with Flatpickr CDN

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -26,8 +26,12 @@
     <link href="{{ asset('assets/vendor/gridjs/theme/mermaid.min.css') }}" rel="stylesheet" type="text/css" />
 
     <!-- Theme Config js -->
-    <script src="{{ asset('assets/js/config.js') }}"></script>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="{{ asset('assets/js/config.js') }}"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+<!-- Flatpickr Datepicker -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
@@ -544,6 +548,18 @@
                     preloader.style.display = 'none';
                 }, 500);
             }, 300); // Delay for better UX
+        });
+    </script>
+    <script>
+        $(function(){
+            $.ajaxSetup({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                }
+            });
+            if (typeof flatpickr !== 'undefined') {
+                $('.date-picker').flatpickr({ dateFormat: 'd-m-Y' });
+            }
         });
     </script>
     <script>

--- a/resources/views/buyer/index.blade.php
+++ b/resources/views/buyer/index.blade.php
@@ -30,6 +30,9 @@
 @push('scripts')
 <script>
     $(function () {
+        if (typeof flatpickr !== 'undefined') {
+            flatpickr('#subscribe_date', {dateFormat: 'd-m-Y'});
+        }
         $('#newsletter-form').on('submit', function (e) {
             e.preventDefault();
             const formErrors = $('#form-errors').addClass('d-none').empty();

--- a/resources/views/buyer/layouts/app.blade.php
+++ b/resources/views/buyer/layouts/app.blade.php
@@ -7,11 +7,25 @@
     <meta name="csrf-token" content="{{ csrf_token() }}" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </head>
 <body>
     @yield('content')
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384" crossorigin="anonymous"></script>
+    <script>
+        $(function(){
+            $.ajaxSetup({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                }
+            });
+            if (typeof flatpickr !== 'undefined') {
+                $('.date-picker').flatpickr({ dateFormat: 'd-m-Y' });
+            }
+        });
+    </script>
     @stack('scripts')
 </body>
 </html>

--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -29,6 +29,10 @@
 <script src="{{ asset('assets/js/config.js') }}"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
+<!-- Flatpickr Datepicker -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+
 <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 


### PR DESCRIPTION
## Summary
- load Flatpickr from CDN in vendor, admin and buyer layouts
- initialize flatpickr on buyer newsletter form
- setup global AJAX headers and date-picker initialization in buyer and admin layouts

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681ecf9b48832792e1d5f952b262cc