### PR TITLE
Add vendor product export

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -201,6 +201,7 @@ Route::middleware(['auth'])->group(function () {
         Route::put('update/{id}', [VendorProductController::class, 'update'])->name('update');
         Route::get('{id}', [VendorProductController::class, 'show'])->name('show');
         Route::delete('delete/{id}', [VendorProductController::class, 'destroy'])->name('destroy');
+        Route::get('export-data', [VendorProductController::class, 'exportData'])->name('export-data');
     });
 
     Route::prefix('vendor/help-support')->name('vendor.help-support.')->group(function () {


### PR DESCRIPTION
## Summary
- allow vendors to export product data via AJAX
- expose new `export-data` route under vendor products
- add ExcelJS-based export button in vendor product list view

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686d5d88deb48327849f93717011efb2