### PR TITLE
Add export filtering

### DIFF
--- a/app/Http/Controllers/Vendor/VendorProductController.php
+++ b/app/Http/Controllers/Vendor/VendorProductController.php
@@ -396,6 +396,8 @@ class VendorProductController extends Controller
         $validator = Validator::make($request->all(), [
             'offset' => 'nullable|integer|min:0',
             'limit' => 'nullable|integer|min:1|max:500',
+            'status' => 'nullable|in:approved,pending,rejected',
+            'product_name' => 'nullable|string|max:200',
         ]);
 
         if ($validator->fails()) {
@@ -407,8 +409,17 @@ class VendorProductController extends Controller
         $offset = (int) $request->input('offset', 0);
         $limit = (int) $request->input('limit', 500);
 
-        $products = Product::where('vendor_id', Auth::id())
-            ->orderBy('id')
+        $productsQuery = Product::where('vendor_id', Auth::id());
+
+        if ($request->filled('status')) {
+            $productsQuery->where('status', $request->status);
+        }
+
+        if ($request->filled('product_name')) {
+            $productsQuery->where('product_name', 'like', '%' . $request->product_name . '%');
+        }
+
+        $products = $productsQuery->orderBy('id')
             ->skip($offset)
             ->take($limit)
             ->get();

--- a/resources/views/vendor/products/index.blade.php
+++ b/resources/views/vendor/products/index.blade.php
@@ -219,6 +219,10 @@ $(document).ready(function() {
 
     async function exportProducts() {
         let offset = 0;
+        const filters = {
+            status: $('#status').val(),
+            product_name: $('#product_name').val()
+        };
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Products');
         worksheet.addRow(['ID','Name','Price','Qty','Status','Created At']);
@@ -228,7 +232,7 @@ $(document).ready(function() {
                 const chunk = await $.ajax({
                     url: "{{ route('vendor.products.export-data') }}",
                     method: 'GET',
-                    data: { offset: offset, limit: 500 }
+                    data: { offset: offset, limit: 500, ...filters }
                 });
 
                 if (chunk.length === 0) {


### PR DESCRIPTION
## Summary
- support filtering by product name and status when exporting vendor products
- pass current filter options from the vendor product listing to the export endpoint

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d626003588327912248c5718c8512