### PR TITLE
Implement placeholders for top products

### DIFF
--- a/resources/views/buyer/index.blade.php
+++ b/resources/views/buyer/index.blade.php
@@ -71,8 +71,33 @@
          </div>
       </div>
       <div class="row" id="topProductCards">
-         <div class="col-12">
-            <p class="text-center mb-0">Loading...</p>
+         <div class="col-md-3 col-sm-6 mb-4" aria-hidden="true">
+            <div class="card placeholder-glow">
+               <div class="card-body py-5">
+                  <span class="placeholder col-12" style="height: 180px;"></span>
+               </div>
+            </div>
+         </div>
+         <div class="col-md-3 col-sm-6 mb-4" aria-hidden="true">
+            <div class="card placeholder-glow">
+               <div class="card-body py-5">
+                  <span class="placeholder col-12" style="height: 180px;"></span>
+               </div>
+            </div>
+         </div>
+         <div class="col-md-3 col-sm-6 mb-4" aria-hidden="true">
+            <div class="card placeholder-glow">
+               <div class="card-body py-5">
+                  <span class="placeholder col-12" style="height: 180px;"></span>
+               </div>
+            </div>
+         </div>
+         <div class="col-md-3 col-sm-6 mb-4" aria-hidden="true">
+            <div class="card placeholder-glow">
+               <div class="card-body py-5">
+                  <span class="placeholder col-12" style="height: 180px;"></span>
+               </div>
+            </div>
          </div>
       </div>
       </div>
@@ -88,7 +113,7 @@
                      </div>
                      <div class="mb-3">
                         <label for="subscribeDate" class="form-label">Subscribe Date</label>
-                        <input type="text" class="form-control date-picker" id="subscribeDate" name="subscribe_date" required>
+                        <input type="text" class="form-control date-picker" id="subscribeDate" name="subscribe_date" placeholder="dd-mm-yyyy" required>
                      </div>
                      <button type="submit" class="btn btn-primary">Subscribe</button>
                   </form>


### PR DESCRIPTION
## Summary
- add skeleton placeholders for top-selling products
- hint date format with a `dd-mm-yyyy` placeholder in newsletter form

## Testing
- `php -v` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebbed81c883279fc6ba4b3da797c5