### PR TITLE
Add vendor global script and SumoSelect support

### DIFF
--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -36,6 +36,10 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 
+<!-- SumoSelect -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.sumoselect/3.1.6/sumoselect.min.css" integrity="sha512-9sIgpQ/Y5bE5B7hR9x8RJWb1x1o1t4bm/FvGV8eK3opgDdGztqKqRR3YKHyCuXapnwXCfJOLLmObEWj1vDLhkw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.sumoselect/3.1.6/jquery.sumoselect.min.js" integrity="sha512-XQCIUQtdgQXl3k5ufADG7n2AFDzy83H8XTur2qxGn8pY/+bexdFv+DE5jBqFaUG2RgxN6E466+vWXTjhBMWrOA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 <style>
     .bi-bell,
@@ -420,6 +424,61 @@ $(function(){
     if (typeof flatpickr !== 'undefined') {
         $('.date-picker').flatpickr({ dateFormat: 'd-m-Y' });
     }
+    if (typeof $.fn.SumoSelect !== 'undefined') {
+        $('select').each(function(){
+            if (!$(this).hasClass('SumoUnder')) {
+                $(this).SumoSelect({search: true, searchText: 'Search...'});
+            }
+        });
+    }
+
+    $('form.ajax-form').on('submit', function(e){
+        e.preventDefault();
+        const $form = $(this);
+        const formData = new FormData(this);
+        $form.find('.is-invalid').removeClass('is-invalid');
+        $form.find('.error-message').remove();
+
+        $.ajax({
+            url: $form.attr('action'),
+            type: $form.attr('method') || 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            beforeSend: function(){
+                $form.find('button[type="submit"]').prop('disabled', true);
+            },
+            success: function(res){
+                if(res.status){
+                    toastr.success(res.message || 'Success');
+                    if(res.redirect){
+                        setTimeout(function(){ window.location.href = res.redirect; }, 800);
+                    }
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            },
+            error: function(xhr){
+                if(xhr.responseJSON && xhr.responseJSON.errors){
+                    $.each(xhr.responseJSON.errors, function(key, val){
+                        const $inp = $form.find('[name="'+key+'"]');
+                        $inp.addClass('is-invalid');
+                        if($inp.next('.error-message').length === 0){
+                            $inp.after('<span class="error-message text-danger">'+val[0]+'</span>');
+                        }
+                        toastr.error(val[0]);
+                    });
+                }else if(xhr.responseJSON && xhr.responseJSON.message){
+                    toastr.error(xhr.responseJSON.message);
+                }else{
+                    toastr.error('An error occurred. Please try again.');
+                }
+            },
+            complete: function(){
+                $form.find('button[type="submit"]').prop('disabled', false);
+            }
+        });
+    });
 });
 </script>
 <script>

--- a/resources/views/vendor/products/create.blade.php
+++ b/resources/views/vendor/products/create.blade.php
@@ -42,7 +42,7 @@
                 </a>
             </div>
             <div class="card-body">
-                <form action="{{ route('vendor.products.store') }}" method="POST" enctype="multipart/form-data" id="productForm">
+                <form action="{{ route('vendor.products.store') }}" method="POST" enctype="multipart/form-data" id="productForm" class="ajax-form">
                     @csrf
                     <div class="row gy-3">
                        <div class="col-md-6">

--- a/resources/views/vendor/products/edit.blade.php
+++ b/resources/views/vendor/products/edit.blade.php
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div class="card-body">
-                <form action="{{ route('vendor.products.update', $product->id) }}" method="POST" enctype="multipart/form-data" id="productForm">
+                <form action="{{ route('vendor.products.update', $product->id) }}" method="POST" enctype="multipart/form-data" id="productForm" class="ajax-form">
                     @csrf
                     @method('PUT')
                     <div class="row gy-3">

--- a/resources/views/vendor/subscriptions/index.blade.php
+++ b/resources/views/vendor/subscriptions/index.blade.php
@@ -13,7 +13,7 @@
                 @endif
             </div>
             <div class="card-body">
-                <form id="subscriptionForm" action="{{ route('vendor.subscription.store') }}" method="POST">
+                <form id="subscriptionForm" action="{{ route('vendor.subscription.store') }}" method="POST" class="ajax-form">
                     @csrf
                     <div class="row">
                         <div class="mb-3 col-md-6 col-lg-4">


### PR DESCRIPTION
## Summary
- add SumoSelect css/js to vendor layout
- initialize SumoSelect for all selects and provide global AJAX form handling
- mark vendor product and subscription forms with `ajax-form` class

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f79a9052c8327bfa305f2bb0eddd5