### PR TITLE
Fix axios include in buyer layout

### DIFF
--- a/resources/views/buyer/layouts/app.blade.php
+++ b/resources/views/buyer/layouts/app.blade.php
@@ -3,3 +3,5 @@
 @yield('content')
 
 @include('buyer.layouts.partials.footer')
+<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+@stack('scripts')


### PR DESCRIPTION
## Summary
- include axios CDN in buyer layout and expose `@stack('scripts')`

## Testing
- `npm install`
- `npm run build`
- *(failed: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffcda84d883279262636c3310fc95