### PR TITLE
Implement dynamic search suggestions in header

### DIFF
--- a/app/Http/Controllers/Buyer/HomeController.php
+++ b/app/Http/Controllers/Buyer/HomeController.php
@@ -45,4 +45,41 @@ class HomeController extends Controller
 
         return response()->json($products);
     }
+
+    /**
+     * Return product and category suggestions for search.
+     */
+    public function searchSuggestions(Request $request)
+    {
+        $validated = $request->validate([
+            'q' => 'required|string|min:1',
+        ]);
+
+        $query = $validated['q'];
+
+        $products = Product::where('status', 'approved')
+            ->where('product_name', 'like', "%{$query}%")
+            ->select('product_name', 'created_at')
+            ->orderBy('product_name')
+            ->take(5)
+            ->get()
+            ->map(function ($item) {
+                return [
+                    'name' => $item->product_name,
+                    'date' => optional($item->created_at)->format('d-m-Y'),
+                ];
+            });
+
+        $categories = Category::where('status', 1)
+            ->where('name', 'like', "%{$query}%")
+            ->select('name')
+            ->orderBy('name')
+            ->take(5)
+            ->get();
+
+        return response()->json([
+            'products' => $products,
+            'categories' => $categories,
+        ]);
+    }
 }

--- a/resources/views/buyer/layouts/partials/header.blade.php
+++ b/resources/views/buyer/layouts/partials/header.blade.php
@@ -19,10 +19,11 @@
                         <div class="header_search_content">
                             <div id="search_block_top" class="search_block_top">
                                 <form id="searchbox" method="get" action="#">
-                                    <input class="search_query form-control" type="text" id="search_query_top" name="s" placeholder="Search For Product...." value="">           
-                                   
+                                    <input class="search_query form-control" type="text" id="search_query_top" name="s" placeholder="Search For Product...." value="">
+
                                     <button type="submit" name="submit_search" class="btn btn-default button-search"><i class="fa fa-search"></i></button>
                                 </form>
+                                <div id="searchSuggestionContainer" class="mt-2"></div>
                             </div>
                         </div>
                     </div>    
@@ -278,5 +279,49 @@
                 }
             }
         });
+
+        var searchInput = document.getElementById('search_query_top');
+        var suggestionContainer = document.getElementById('searchSuggestionContainer');
+
+        function renderSuggestions(data) {
+            var html = '';
+            if ((data.products && data.products.length) || (data.categories && data.categories.length)) {
+                html += '<div class="row"><div class="col-md-12"><div class="card"><div class="card-body p-2">';
+                if (data.products && data.products.length) {
+                    html += '<ul class="list-group list-group-flush">';
+                    data.products.forEach(function (p) {
+                        var date = p.date ? ' <span class="text-muted small">(' + p.date + ')</span>' : '';
+                        html += '<li class="list-group-item">' + p.name + date + '</li>';
+                    });
+                    html += '</ul>';
+                }
+                if (data.categories && data.categories.length) {
+                    html += '<ul class="list-group list-group-flush mt-2">';
+                    data.categories.forEach(function (c) {
+                        html += '<li class="list-group-item">' + c.name + '</li>';
+                    });
+                    html += '</ul>';
+                }
+                html += '</div></div></div></div>';
+            }
+            suggestionContainer.innerHTML = html;
+        }
+
+        if (searchInput) {
+            searchInput.addEventListener('keyup', function () {
+                var q = this.value.trim();
+                if (q.length < 2) {
+                    suggestionContainer.innerHTML = '';
+                    return;
+                }
+                axios.get('{{ route('buyer.search-suggestions') }}', { params: { q: q } })
+                    .then(function (res) {
+                        renderSuggestions(res.data);
+                    })
+                    .catch(function () {
+                        suggestionContainer.innerHTML = '';
+                    });
+            });
+        }
     });
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -240,5 +240,6 @@ Route::get('/buyer/dashboard', function () {
 Route::get('/buyer', [HomeController::class, 'index'])->name('buyer.index');
 Route::get('/buyer/categories', [HomeController::class, 'categories'])->name('buyer.categories');
 Route::get('/buyer/top-products', [HomeController::class, 'topProducts'])->name('buyer.top-products');
+Route::get('/buyer/search-suggestions', [HomeController::class, 'searchSuggestions'])->name('buyer.search-suggestions');
 
 Route::post('/newsletter/subscribe', [\App\Http\Controllers\NewsletterController::class, 'store'])->name('newsletter.subscribe');


### PR DESCRIPTION
## Summary
- add route and controller method for product/category search suggestions
- fetch suggestions with AJAX in buyer header search bar
- show suggestions in a card layout and format product dates as `dd-mm-yyyy`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68714538f3dc8327a631fb90412336fc