### PR TITLE
Implement sub-category and product pages

### DIFF
--- a/app/Http/Controllers/Buyer/HomeController.php
+++ b/app/Http/Controllers/Buyer/HomeController.php
@@ -7,12 +7,37 @@ use App\Models\Category;
 use App\Models\Product;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class HomeController extends Controller
 {
     public function index()
     {
         return view('buyer.index');
+    }
+
+    /**
+     * Display sub category page for selected category.
+     */
+    public function subCategoryPage($categoryId)
+    {
+        $data = Validator::make(['id' => $categoryId], [
+            'id' => 'required|integer|exists:categories,id',
+        ])->validate();
+
+        return view('buyer.subcategories', ['categoryId' => $data['id']]);
+    }
+
+    /**
+     * Display product page for selected sub category.
+     */
+    public function productPage($subCategoryId)
+    {
+        $data = Validator::make(['id' => $subCategoryId], [
+            'id' => 'required|integer|exists:categories,id',
+        ])->validate();
+
+        return view('buyer.products', ['subCategoryId' => $data['id']]);
     }
 
     /**
@@ -81,5 +106,39 @@ class HomeController extends Controller
             'products' => $products,
             'categories' => $categories,
         ]);
+    }
+
+    /**
+     * Return sub categories for given category.
+     */
+    public function subCategories($categoryId)
+    {
+        $data = Validator::make(['id' => $categoryId], [
+            'id' => 'required|integer|exists:categories,id',
+        ])->validate();
+
+        $sub = Category::where('status', 1)
+            ->where('parent_id', $data['id'])
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        return response()->json($sub);
+    }
+
+    /**
+     * Return products list for selected sub category.
+     */
+    public function productsBySubCategory($subCategoryId)
+    {
+        $data = Validator::make(['id' => $subCategoryId], [
+            'id' => 'required|integer|exists:categories,id',
+        ])->validate();
+
+        $products = Product::where('status', 'approved')
+            ->where('sub_category_id', $data['id'])
+            ->orderBy('product_name')
+            ->get(['product_name', 'product_image']);
+
+        return response()->json($products);
     }
 }

--- a/resources/views/buyer/index.blade.php
+++ b/resources/views/buyer/index.blade.php
@@ -65,6 +65,8 @@
 
 
 
+
+
       <div class="row mb-4">
          <div class="col-12">
             <h5>Our Top Selling Products</h5>
@@ -131,6 +133,16 @@
 @push('scripts')
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    function attachCategoryHandlers() {
+        document.querySelectorAll('.category-card').forEach(function (el) {
+            el.addEventListener('click', function () {
+                var id = this.getAttribute('data-id');
+                if (!/^\d+$/.test(id)) return;
+                window.location.href = '/buyer/category/' + id + '/sub-categories';
+            });
+        });
+    }
+
     // Load categories
     axios.get('{{ route('buyer.categories') }}').then(function (response) {
         var container = document.getElementById('categoryCards');
@@ -139,12 +151,13 @@ document.addEventListener('DOMContentLoaded', function () {
         if (data.length) {
             data.forEach(function (cat) {
                 var html = '<div class="col-md-3 col-sm-6 mb-3">' +
-                    '<div class="card text-center shadow-sm category-card">' +
+                    '<div class="card text-center shadow-sm category-card" data-id="' + cat.id + '">' +
                     '<div class="card-body py-3">' +
                     '<h6 class="mb-0">' + cat.name + '</h6>' +
                     '</div></div></div>';
                 container.insertAdjacentHTML('beforeend', html);
             });
+            attachCategoryHandlers();
         } else {
             container.innerHTML = '<div class="col-12"><p class="text-center mb-0">No categories found.</p></div>';
         }

--- a/resources/views/buyer/products.blade.php
+++ b/resources/views/buyer/products.blade.php
@@ -1,0 +1,53 @@
+@extends('buyer.layouts.app')
+@section('title', 'Fixfellow - Products')
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row mb-3">
+            <div class="col-12">
+                <a href="javascript:history.back()" class="btn btn-link">&larr; Back</a>
+            </div>
+        </div>
+        <div class="row mb-5">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row" id="productCards"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var subId = {{ $subCategoryId }};
+    axios.get('/buyer/products/' + subId)
+        .then(function (res) { render(res.data); })
+        .catch(function () { render([]); });
+
+    function render(list) {
+        var container = document.getElementById('productCards');
+        container.innerHTML = '';
+        if (list.length) {
+            list.forEach(function (prod) {
+                var imageSection = prod.product_image ? '<img src="' + prod.product_image + '" class="card-img-top" alt="' + prod.product_name + '">' : '';
+                var card = '<div class="col-md-3 col-sm-6 mb-3">' +
+                        '<div class="card h-100 border shadow-sm">' +
+                            imageSection +
+                            '<div class="card-body text-center">' +
+                                '<h6 class="card-title mb-0">' + prod.product_name + '</h6>' +
+                            '</div>' +
+                        '</div>' +
+                    '</div>';
+                container.insertAdjacentHTML('beforeend', card);
+            });
+        } else {
+            container.innerHTML = '<div class="col-12"><p class="text-center mb-0">No products found.</p></div>';
+        }
+    }
+});
+</script>
+@endpush

--- a/resources/views/buyer/subcategories.blade.php
+++ b/resources/views/buyer/subcategories.blade.php
@@ -1,0 +1,62 @@
+@extends('buyer.layouts.app')
+@section('title', 'Fixfellow - Sub Categories')
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row mb-3">
+            <div class="col-12">
+                <a href="{{ route('buyer.index') }}" class="btn btn-link">&larr; Back to Categories</a>
+            </div>
+        </div>
+        <div class="row mb-5">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row" id="subCategoryCards"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var categoryId = {{ $categoryId }};
+    axios.get('/buyer/sub-categories/' + categoryId)
+        .then(function (res) { render(res.data); })
+        .catch(function () { render([]); });
+
+    function render(list) {
+        var container = document.getElementById('subCategoryCards');
+        container.innerHTML = '';
+        if (list.length) {
+            list.forEach(function (sub) {
+                var html = '<div class="col-md-3 col-sm-6 mb-3">' +
+                    '<div class="card text-center shadow-sm subcategory-card" data-id="' + sub.id + '">' +
+                        '<div class="card-body py-3">' +
+                            '<h6 class="mb-0">' + sub.name + '</h6>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+                container.insertAdjacentHTML('beforeend', html);
+            });
+            attachHandlers();
+        } else {
+            container.innerHTML = '<div class="col-12"><p class="text-center mb-0">No sub categories found.</p></div>';
+        }
+    }
+
+    function attachHandlers() {
+        document.querySelectorAll('.subcategory-card').forEach(function (el) {
+            el.addEventListener('click', function () {
+                var id = this.getAttribute('data-id');
+                if (!/^\d+$/.test(id)) return;
+                window.location.href = '/buyer/sub-category/' + id + '/products';
+            });
+        });
+    }
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -238,7 +238,11 @@ Route::get('/buyer/dashboard', function () {
 
 
 Route::get('/buyer', [HomeController::class, 'index'])->name('buyer.index');
+Route::get('/buyer/category/{category}/sub-categories', [HomeController::class, 'subCategoryPage'])->name('buyer.sub-category-page');
+Route::get('/buyer/sub-category/{subCategory}/products', [HomeController::class, 'productPage'])->name('buyer.product-page');
 Route::get('/buyer/categories', [HomeController::class, 'categories'])->name('buyer.categories');
+Route::get('/buyer/sub-categories/{category}', [HomeController::class, 'subCategories'])->name('buyer.sub-categories');
+Route::get('/buyer/products/{subCategory}', [HomeController::class, 'productsBySubCategory'])->name('buyer.subcategory-products');
 Route::get('/buyer/top-products', [HomeController::class, 'topProducts'])->name('buyer.top-products');
 Route::get('/buyer/search-suggestions', [HomeController::class, 'searchSuggestions'])->name('buyer.search-suggestions');
 


### PR DESCRIPTION
## Summary
- open sub-category and product lists on dedicated pages instead of inline
- show sub-category and product cards using AJAX on those pages
- update category click handler to navigate to the new pages
- validate category IDs in the controller when loading pages

## Testing
- `composer install --no-interaction --no-progress`
- `cp .env.example .env`
- `php artisan key:generate --force`
- `php artisan test --compact`


------
https://chatgpt.com/codex/tasks/task_e_68736f3e7fc083278823717db0e84c58