### PR TITLE
Add slug based buyer categories

### DIFF
--- a/app/Http/Controllers/Buyer/HomeController.php
+++ b/app/Http/Controllers/Buyer/HomeController.php
@@ -19,13 +19,26 @@ class HomeController extends Controller
     /**
      * Display sub category page for selected category.
      */
-    public function subCategoryPage($categoryId)
+    public function subCategoryPage($slug)
     {
-        $data = Validator::make(['id' => $categoryId], [
-            'id' => 'required|integer|exists:categories,id',
+        $data = Validator::make(['slug' => $slug], [
+            'slug' => 'required|string|exists:categories,slug',
         ])->validate();
 
-        return view('buyer.subcategories', ['categoryId' => $data['id']]);
+        $category = Category::where('slug', $data['slug'])
+            ->where('parent_id', 0)
+            ->where('status', 1)
+            ->firstOrFail();
+
+        $subcategories = Category::where('status', 1)
+            ->where('parent_id', $category->id)
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        return view('buyer.subcategories', [
+            'category' => $category,
+            'subcategories' => $subcategories,
+        ]);
     }
 
     /**
@@ -51,7 +64,7 @@ class HomeController extends Controller
                 $q->where('status', 1)->orderBy('name');
             }])
             ->orderBy('name')
-            ->get(['id', 'name']);
+            ->get(['id', 'name', 'slug']);
 
         return response()->json($categories);
     }

--- a/resources/views/buyer/index.blade.php
+++ b/resources/views/buyer/index.blade.php
@@ -136,10 +136,10 @@ document.addEventListener('DOMContentLoaded', function () {
     function attachCategoryHandlers() {
         document.querySelectorAll('.category-card').forEach(function (el) {
             el.addEventListener('click', function (e) {
-                var id = this.getAttribute('data-id');
-                if (!/^\d+$/.test(id)) return;
+                var slug = this.getAttribute('data-slug');
+                if (!slug) return;
                 e.preventDefault();
-                window.location.href = '/buyer/category/' + id + '/sub-categories';
+                window.location.href = '/buyer/category/' + slug;
             });
         });
     }
@@ -151,9 +151,9 @@ document.addEventListener('DOMContentLoaded', function () {
         var data = response.data;
         if (data.length) {
             data.forEach(function (cat) {
-                var url = '/buyer/category/' + cat.id + '/sub-categories';
+                var url = '/buyer/category/' + cat.slug;
                 var html = '<div class="col-md-3 col-sm-6 mb-3">' +
-                    '<a href="' + url + '" class="card text-center shadow-sm category-card" data-id="' + cat.id + '">' +
+                    '<a href="' + url + '" class="card text-center shadow-sm category-card" data-slug="' + cat.slug + '">' +
                     '<div class="card-body py-3">' +
                     '<h6 class="mb-0">' + cat.name + '</h6>' +
                     '</div></a></div>';

--- a/resources/views/buyer/subcategories.blade.php
+++ b/resources/views/buyer/subcategories.blade.php
@@ -12,7 +12,21 @@
             <div class="col-md-12">
                 <div class="card">
                     <div class="card-body">
-                        <div class="row" id="subCategoryCards"></div>
+                        <div class="row">
+                            @forelse($subcategories as $sub)
+                                <div class="col-md-3 col-sm-6 mb-3">
+                                    <a href="{{ route('buyer.product-page', $sub->id) }}" class="card text-center shadow-sm">
+                                        <div class="card-body py-3">
+                                            <h6 class="mb-0">{{ $sub->name }}</h6>
+                                        </div>
+                                    </a>
+                                </div>
+                            @empty
+                                <div class="col-12">
+                                    <p class="text-center mb-0">No sub categories found.</p>
+                                </div>
+                            @endforelse
+                        </div>
                     </div>
                 </div>
             </div>
@@ -20,43 +34,3 @@
     </div>
 </section>
 @endsection
-@push('scripts')
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    var categoryId = {{ $categoryId }};
-    axios.get('/buyer/sub-categories/' + categoryId)
-        .then(function (res) { render(res.data); })
-        .catch(function () { render([]); });
-
-    function render(list) {
-        var container = document.getElementById('subCategoryCards');
-        container.innerHTML = '';
-        if (list.length) {
-            list.forEach(function (sub) {
-                var html = '<div class="col-md-3 col-sm-6 mb-3">' +
-                    '<div class="card text-center shadow-sm subcategory-card" data-id="' + sub.id + '">' +
-                        '<div class="card-body py-3">' +
-                            '<h6 class="mb-0">' + sub.name + '</h6>' +
-                        '</div>' +
-                    '</div>' +
-                '</div>';
-                container.insertAdjacentHTML('beforeend', html);
-            });
-            attachHandlers();
-        } else {
-            container.innerHTML = '<div class="col-12"><p class="text-center mb-0">No sub categories found.</p></div>';
-        }
-    }
-
-    function attachHandlers() {
-        document.querySelectorAll('.subcategory-card').forEach(function (el) {
-            el.addEventListener('click', function () {
-                var id = this.getAttribute('data-id');
-                if (!/^\d+$/.test(id)) return;
-                window.location.href = '/buyer/sub-category/' + id + '/products';
-            });
-        });
-    }
-});
-</script>
-@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -238,7 +238,7 @@ Route::get('/buyer/dashboard', function () {
 
 
 Route::get('/buyer', [HomeController::class, 'index'])->name('buyer.index');
-Route::get('/buyer/category/{category}/sub-categories', [HomeController::class, 'subCategoryPage'])->name('buyer.sub-category-page');
+Route::get('/buyer/category/{slug}', [HomeController::class, 'subCategoryPage'])->name('buyer.sub-category-page');
 Route::get('/buyer/sub-category/{subCategory}/products', [HomeController::class, 'productPage'])->name('buyer.product-page');
 Route::get('/buyer/categories', [HomeController::class, 'categories'])->name('buyer.categories');
 Route::get('/buyer/sub-categories/{category}', [HomeController::class, 'subCategories'])->name('buyer.sub-categories');


### PR DESCRIPTION
## Summary
- link categories using slug-based URLs
- fetch category slugs in the API
- show subcategories via blade loop
- update route to accept slug

## Testing
- `composer install`
- `php artisan key:generate`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6874cd1f8ae483279442f8c5e086e068