### PR TITLE
Add Post Buy Requirement page

### DIFF
--- a/app/Http/Controllers/Buyer/BuyRequirementController.php
+++ b/app/Http/Controllers/Buyer/BuyRequirementController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Buyer;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use App\Models\BuyRequirement;
+use Carbon\Carbon;
+
+class BuyRequirementController extends Controller
+{
+    public function create()
+    {
+        return view('buyer.post_buy');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'product_name'  => 'required|string|max:255',
+            'country_code'  => 'required|string|max:5',
+            'mobile_number' => 'required|string|max:20',
+            'expected_date' => 'nullable|date_format:d-m-Y',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status'  => 0,
+                    'message' => $validator->errors()->first(),
+                    'errors'  => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $data = $validator->validated();
+        if (!empty($data['expected_date'])) {
+            $data['expected_date'] = Carbon::createFromFormat('d-m-Y', $data['expected_date'])->format('Y-m-d');
+        }
+
+        BuyRequirement::create($data);
+
+        if ($request->ajax()) {
+            return response()->json([
+                'status'  => 1,
+                'message' => 'Requirement submitted successfully!',
+            ]);
+        }
+
+        return redirect()->back()->with('success', 'Requirement submitted successfully!');
+    }
+}

--- a/app/Models/BuyRequirement.php
+++ b/app/Models/BuyRequirement.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BuyRequirement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_name',
+        'country_code',
+        'mobile_number',
+        'expected_date',
+    ];
+
+    protected $casts = [
+        'expected_date' => 'date',
+    ];
+}

--- a/database/migrations/2025_06_23_000000_create_buy_requirements_table.php
+++ b/database/migrations/2025_06_23_000000_create_buy_requirements_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('buy_requirements', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('product_name');
+            $table->string('country_code', 5);
+            $table->string('mobile_number', 20);
+            $table->date('expected_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('buy_requirements');
+    }
+};

--- a/resources/views/buyer/post_buy.blade.php
+++ b/resources/views/buyer/post_buy.blade.php
@@ -1,0 +1,85 @@
+@extends('buyer.layouts.app')
+@section('title','Post Buy Requirement')
+@section('content')
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Post Buy Requirement</h4>
+            </div>
+            <div class="card-body">
+                <form id="buyReqForm" action="{{ route('buyer.post-buy.store') }}" method="POST">
+                    @csrf
+                    <div class="mb-3">
+                        <label for="product_name" class="form-label">Product Name <span class="text-danger">*</span></label>
+                        <input type="text" name="product_name" id="product_name" class="form-control" placeholder="Enter the product you are looking for...">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Mobile Number <span class="text-danger">*</span></label>
+                        <div class="input-group">
+                            <select name="country_code" id="country_code" class="form-select" style="max-width:120px">
+                                <option value="91">+91</option>
+                                <option value="1">+1</option>
+                                <option value="44">+44</option>
+                            </select>
+                            <input type="text" name="mobile_number" id="mobile_number" class="form-control" placeholder="Enter Mobile Number">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="expected_date" class="form-label">Expected Date</label>
+                        <input type="text" name="expected_date" id="expected_date" class="form-control date-picker" placeholder="dd-mm-yyyy">
+                    </div>
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-primary">Get Best Deal</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script>
+$(function(){
+    if (typeof flatpickr !== 'undefined') {
+        $('#expected_date').flatpickr({dateFormat:'d-m-Y'});
+    }
+    $.ajaxSetup({
+        headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')}
+    });
+    $('#buyReqForm').on('submit', function(e){
+        e.preventDefault();
+        var form = $(this);
+        form.find('.is-invalid').removeClass('is-invalid');
+        form.find('.invalid-feedback').remove();
+        $.post(form.attr('action'), form.serialize())
+            .done(function(res){
+                if(res.status){
+                    toastr.success(res.message);
+                    form[0].reset();
+                }else{
+                    toastr.error(res.message || 'An error occurred');
+                }
+            })
+            .fail(function(xhr){
+                if(xhr.status===422){
+                    $.each(xhr.responseJSON.errors, function(key,val){
+                        var inp = form.find('[name="'+key+'"]');
+                        inp.addClass('is-invalid');
+                        inp.after('<div class="invalid-feedback d-block">'+val[0]+'</div>');
+                        toastr.error(val[0]);
+                    });
+                }else{
+                    toastr.error(xhr.responseJSON?.message || 'An error occurred');
+                }
+            });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Vendor\VendorProductController;
 use App\Http\Controllers\Vendor\VendorSubscriptionController;
 use App\Http\Controllers\Vendor\VendorPasswordController;
 use App\Http\Controllers\Buyer\HomeController;
+use App\Http\Controllers\Buyer\BuyRequirementController;
 
 Route::get('/clear-cache', function () {
     Artisan::call('optimize:clear');
@@ -245,5 +246,7 @@ Route::get('/buyer/sub-categories/{category}', [HomeController::class, 'subCateg
 Route::get('/buyer/products/{subCategory}', [HomeController::class, 'productsBySubCategory'])->name('buyer.subcategory-products');
 Route::get('/buyer/top-products', [HomeController::class, 'topProducts'])->name('buyer.top-products');
 Route::get('/buyer/search-suggestions', [HomeController::class, 'searchSuggestions'])->name('buyer.search-suggestions');
+Route::get('/buyer/post-buy', [BuyRequirementController::class, 'create'])->name('buyer.post-buy.create');
+Route::post('/buyer/post-buy', [BuyRequirementController::class, 'store'])->name('buyer.post-buy.store');
 
 Route::post('/newsletter/subscribe', [\App\Http\Controllers\NewsletterController::class, 'store'])->name('newsletter.subscribe');


### PR DESCRIPTION
## Summary
- add migration for buy requirements
- add model and controller for posting buy requirements
- expose new buyer routes
- create Post Buy Requirement form with ajax validation

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_6875420c70ac832784f9ba076c95ece5