### PR TITLE
Add buyer product list with AJAX pagination

### DIFF
--- a/app/Http/Controllers/Buyer/ProductController.php
+++ b/app/Http/Controllers/Buyer/ProductController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Buyer;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class ProductController extends Controller
+{
+    /**
+     * Display product list page.
+     */
+    public function index()
+    {
+        return view('buyer.product_list');
+    }
+
+    /**
+     * Return paginated products in JSON format.
+     */
+    public function list(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'page' => 'sometimes|integer|min:1',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 0,
+                'message' => $validator->errors()->first(),
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $perPage = 24;
+        $page = $request->input('page', 1);
+
+        $products = Product::where('status', 'approved')
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage, ['*'], 'page', $page);
+
+        $items = $products->getCollection()->map(function ($item) {
+            return [
+                'id' => $item->id,
+                'product_name' => $item->product_name,
+                'product_image' => $item->product_image ? asset('storage/' . $item->product_image) : null,
+                'date' => optional($item->created_at)->format('d-m-Y'),
+            ];
+        });
+
+        return response()->json([
+            'status' => 1,
+            'products' => $items,
+            'has_more' => $products->hasMorePages(),
+        ]);
+    }
+}

--- a/resources/views/buyer/product_list.blade.php
+++ b/resources/views/buyer/product_list.blade.php
@@ -1,0 +1,74 @@
+@extends('buyer.layouts.app')
+@section('title', 'Products')
+@section('content')
+<section class="py-5">
+    <div class="container">
+        <div class="row mb-5">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row" id="productContainer"></div>
+                        <div class="text-center mt-3">
+                            <button id="loadMoreBtn" class="btn btn-primary">Load More</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var page = 1;
+    loadProducts(page);
+
+    document.getElementById('loadMoreBtn').addEventListener('click', function () {
+        page++;
+        loadProducts(page);
+    });
+
+    function loadProducts(pg) {
+        var btn = document.getElementById('loadMoreBtn');
+        btn.disabled = true;
+        axios.get('{{ route('buyer.products.list') }}', { params: { page: pg } })
+            .then(function (res) {
+                if (res.data.status) {
+                    appendProducts(res.data.products);
+                    if (res.data.has_more) {
+                        btn.disabled = false;
+                    } else {
+                        btn.style.display = 'none';
+                    }
+                } else {
+                    btn.style.display = 'none';
+                }
+            })
+            .catch(function (error) {
+                if (error.response && error.response.status === 422) {
+                    alert(error.response.data.message);
+                }
+                btn.disabled = false;
+            });
+    }
+
+    function appendProducts(list) {
+        var container = document.getElementById('productContainer');
+        list.forEach(function (prod) {
+            var img = prod.product_image ? '<img src="' + prod.product_image + '" class="card-img-top" alt="' + prod.product_name + '">' : '';
+            var html = '<div class="col-md-3 col-sm-6 mb-3">' +
+                        '<div class="card h-100 border shadow-sm">' +
+                            img +
+                            '<div class="card-body text-center">' +
+                                '<h6 class="card-title mb-1">' + prod.product_name + '</h6>' +
+                                '<small class="text-muted">' + (prod.date || '') + '</small>' +
+                            '</div>' +
+                        '</div>' +
+                    '</div>';
+            container.insertAdjacentHTML('beforeend', html);
+        });
+    }
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -249,4 +249,8 @@ Route::get('/buyer/search-suggestions', [HomeController::class, 'searchSuggestio
 Route::get('/buyer/post-buy', [BuyRequirementController::class, 'create'])->name('buyer.post-buy.create');
 Route::post('/buyer/post-buy', [BuyRequirementController::class, 'store'])->name('buyer.post-buy.store');
 
+// Product list with load more
+Route::get('/buyer/products-list', [\App\Http\Controllers\Buyer\ProductController::class, 'index'])->name('buyer.products.list-page');
+Route::get('/buyer/products-list/data', [\App\Http\Controllers\Buyer\ProductController::class, 'list'])->name('buyer.products.list');
+
 Route::post('/newsletter/subscribe', [\App\Http\Controllers\NewsletterController::class, 'store'])->name('newsletter.subscribe');


### PR DESCRIPTION
## Summary
- add ProductController to serve a paginated product list for buyers
- create product_list view with Load More button
- expose new routes for the buyer product list

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68755a434ff48327b2e6f03324952094