### PR TITLE
Add UserAccount model with AJAX validated CRUD

### DIFF
--- a/app/Http/Controllers/Admin/UserAccountController.php
+++ b/app/Http/Controllers/Admin/UserAccountController.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserAccount;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class UserAccountController extends Controller
+{
+    public function index()
+    {
+        $accounts = UserAccount::orderBy('created_at', 'desc')->get();
+        return view('admin.user_accounts.index', compact('accounts'));
+    }
+
+    public function create()
+    {
+        return view('admin.user_accounts.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = \Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:user_accounts,email',
+            'phone' => 'required|string|max:20|unique:user_accounts,phone',
+            'password' => 'required|string|min:8',
+            'user_type' => 'required|string|max:50',
+            'gender' => 'nullable|string|max:20',
+            'gst_no' => 'nullable|string|max:30',
+            'otp' => 'nullable|string|max:10',
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+            'status' => ['required', Rule::in(['1','2'])],
+            'referral_code' => 'nullable|string|max:20',
+            'referral_by' => 'nullable|string|max:20',
+            'is_verified' => ['required', Rule::in(['1','2'])],
+            'product_and_services' => 'nullable|string',
+            'parent_id' => 'nullable|integer',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $data = $validator->validated();
+        $data['password'] = bcrypt($data['password']);
+
+        try {
+            UserAccount::create($data);
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 1,
+                    'message' => 'User account created successfully!',
+                    'redirect' => route('admin.user-accounts.index'),
+                ]);
+            }
+        } catch (\Exception $e) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'message' => 'Failed to create user account: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        return redirect()->route('admin.user-accounts.index')
+            ->with('success', 'User account created successfully!');
+    }
+
+    public function edit($id)
+    {
+        $account = UserAccount::findOrFail($id);
+        return view('admin.user_accounts.edit', compact('account'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $account = UserAccount::findOrFail($id);
+
+        $validator = \Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'email' => ['required','email',Rule::unique('user_accounts')->ignore($account->id)],
+            'phone' => ['required','string','max:20',Rule::unique('user_accounts','phone')->ignore($account->id)],
+            'password' => 'nullable|string|min:8',
+            'user_type' => 'required|string|max:50',
+            'gender' => 'nullable|string|max:20',
+            'gst_no' => 'nullable|string|max:30',
+            'otp' => 'nullable|string|max:10',
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+            'status' => ['required', Rule::in(['1','2'])],
+            'referral_code' => 'nullable|string|max:20',
+            'referral_by' => 'nullable|string|max:20',
+            'is_verified' => ['required', Rule::in(['1','2'])],
+            'product_and_services' => 'nullable|string',
+            'parent_id' => 'nullable|integer',
+        ]);
+
+        if ($validator->fails()) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $data = $validator->validated();
+        if (!empty($data['password'])) {
+            $data['password'] = bcrypt($data['password']);
+        } else {
+            unset($data['password']);
+        }
+
+        try {
+            $account->update($data);
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 1,
+                    'message' => 'User account updated successfully!',
+                    'redirect' => route('admin.user-accounts.index'),
+                ]);
+            }
+        } catch (\Exception $e) {
+            if ($request->ajax()) {
+                return response()->json([
+                    'status' => 0,
+                    'message' => 'Failed to update user account: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        return redirect()->route('admin.user-accounts.index')
+            ->with('success', 'User account updated successfully!');
+    }
+}

--- a/app/Models/UserAccount.php
+++ b/app/Models/UserAccount.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserAccount extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'password',
+        'user_type',
+        'gender',
+        'gst_no',
+        'otp',
+        'latitude',
+        'longitude',
+        'status',
+        'referral_code',
+        'referral_by',
+        'is_verified',
+        'product_and_services',
+        'parent_id',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+}

--- a/database/migrations/2025_08_06_174921_create_user_accounts_table.php
+++ b/database/migrations/2025_08_06_174921_create_user_accounts_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_accounts', function (Blueprint $table) {
+            $table->unsignedBigInteger('id')->autoIncrement()->primary();
+            $table->string('name', 255);
+            $table->string('email', 255)->unique();
+            $table->string('phone', 20)->unique();
+            $table->string('password', 255);
+            $table->string('user_type', 50);
+            $table->string('gender', 20)->nullable();
+            $table->string('gst_no', 30)->nullable();
+            $table->string('otp', 10)->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->enum('status', ['1', '2'])->default('1')->comment('1->Active, 2->Inactive');
+            $table->string('referral_code', 20)->nullable();
+            $table->string('referral_by', 20)->nullable();
+            $table->enum('is_verified', ['1', '2'])->default('1')->comment('1->Verified, 2->Not Verified');
+            $table->text('product_and_services')->nullable();
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_accounts');
+    }
+};

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -479,6 +479,9 @@
                                 <li class="sub-nav-item">
                                     <a class="sub-nav-link" href="{{ route('admin.users.index') }}">Admin User</a>
                                 </li>
+                                <li class="sub-nav-item">
+                                    <a class="sub-nav-link" href="{{ route('admin.user-accounts.index') }}">User Accounts</a>
+                                </li>
                             </ul>
                         </div>
                     </li>

--- a/resources/views/admin/user_accounts/create.blade.php
+++ b/resources/views/admin/user_accounts/create.blade.php
@@ -1,0 +1,148 @@
+@extends('admin.layouts.app')
+@section('title', 'Add User Account | Deal24hours')
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="card-title mb-0">Add User Account</h4>
+                </div>
+                <div class="card-body">
+                    <form action="{{ route('admin.user-accounts.store') }}" method="POST" id="accountForm">
+                        @csrf
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Phone</label>
+                            <input type="text" name="phone" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Password</label>
+                            <input type="password" name="password" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">User Type</label>
+                            <input type="text" name="user_type" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Gender</label>
+                            <input type="text" name="gender" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">GST No</label>
+                            <input type="text" name="gst_no" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">OTP</label>
+                            <input type="text" name="otp" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Latitude</label>
+                            <input type="number" step="0.0000001" name="latitude" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Longitude</label>
+                            <input type="number" step="0.0000001" name="longitude" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1">Active</option>
+                                <option value="2">Inactive</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Referral Code</label>
+                            <input type="text" name="referral_code" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Referral By</label>
+                            <input type="text" name="referral_by" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Verified</label>
+                            <select name="is_verified" class="form-select" required>
+                                <option value="1">Verified</option>
+                                <option value="2">Not Verified</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Product and Services</label>
+                            <textarea name="product_and_services" class="form-control" rows="3"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Parent ID</label>
+                            <input type="number" name="parent_id" class="form-control">
+                        </div>
+                        <button type="submit" class="btn btn-primary">Save</button>
+                        <a href="{{ route('admin.user-accounts.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        $(document).ready(function() {
+            function validateForm() {
+                let isValid = true;
+                $('#accountForm .error-message').remove();
+                $('#accountForm input[required], #accountForm select[required]').each(function() {
+                    if (!$(this).val()) {
+                        isValid = false;
+                        $(this).addClass('is-invalid');
+                        $(this).after('<span class="text-danger error-message">This field is required</span>');
+                    } else {
+                        $(this).removeClass('is-invalid');
+                    }
+                });
+                return isValid;
+            }
+            $('#accountForm').on('submit', function(e) {
+                e.preventDefault();
+                if (!validateForm()) {
+                    toastr.error('Please fix the validation errors.');
+                    return false;
+                }
+                var formData = $(this).serialize();
+                $.ajax({
+                    url: $(this).attr('action'),
+                    type: 'POST',
+                    data: formData,
+                    beforeSend: function() {
+                        $('button[type="submit"]').prop('disabled', true).html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Saving...');
+                    },
+                    success: function(response) {
+                        if (response.status == 1) {
+                            toastr.success(response.message);
+                            setTimeout(function() {
+                                window.location.href = response.redirect || "{{ route('admin.user-accounts.index') }}";
+                            }, 1000);
+                        } else {
+                            toastr.error(response.message || 'An error occurred');
+                        }
+                    },
+                    error: function(xhr) {
+                        if (xhr.responseJSON && xhr.responseJSON.errors) {
+                            $.each(xhr.responseJSON.errors, function(key, value) {
+                                toastr.error(value[0]);
+                            });
+                        } else if (xhr.responseJSON && xhr.responseJSON.message) {
+                            toastr.error(xhr.responseJSON.message);
+                        } else {
+                            toastr.error('An error occurred. Please try again.');
+                        }
+                    },
+                    complete: function() {
+                        $('button[type="submit"]').prop('disabled', false).html('Save');
+                    }
+                });
+            });
+        });
+    </script>
+@endsection

--- a/resources/views/admin/user_accounts/edit.blade.php
+++ b/resources/views/admin/user_accounts/edit.blade.php
@@ -1,0 +1,149 @@
+@extends('admin.layouts.app')
+@section('title', 'Edit User Account | Deal24hours')
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="card-title mb-0">Edit User Account</h4>
+                </div>
+                <div class="card-body">
+                    <form action="{{ route('admin.user-accounts.update', $account->id) }}" method="POST" id="accountForm">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" value="{{ $account->name }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" value="{{ $account->email }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Phone</label>
+                            <input type="text" name="phone" class="form-control" value="{{ $account->phone }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Password</label>
+                            <input type="password" name="password" class="form-control" placeholder="Leave blank to keep current">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">User Type</label>
+                            <input type="text" name="user_type" class="form-control" value="{{ $account->user_type }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Gender</label>
+                            <input type="text" name="gender" class="form-control" value="{{ $account->gender }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">GST No</label>
+                            <input type="text" name="gst_no" class="form-control" value="{{ $account->gst_no }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">OTP</label>
+                            <input type="text" name="otp" class="form-control" value="{{ $account->otp }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Latitude</label>
+                            <input type="number" step="0.0000001" name="latitude" class="form-control" value="{{ $account->latitude }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Longitude</label>
+                            <input type="number" step="0.0000001" name="longitude" class="form-control" value="{{ $account->longitude }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1" {{ $account->status == '1' ? 'selected' : '' }}>Active</option>
+                                <option value="2" {{ $account->status == '2' ? 'selected' : '' }}>Inactive</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Referral Code</label>
+                            <input type="text" name="referral_code" class="form-control" value="{{ $account->referral_code }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Referral By</label>
+                            <input type="text" name="referral_by" class="form-control" value="{{ $account->referral_by }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Verified</label>
+                            <select name="is_verified" class="form-select" required>
+                                <option value="1" {{ $account->is_verified == '1' ? 'selected' : '' }}>Verified</option>
+                                <option value="2" {{ $account->is_verified == '2' ? 'selected' : '' }}>Not Verified</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Product and Services</label>
+                            <textarea name="product_and_services" class="form-control" rows="3">{{ $account->product_and_services }}</textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Parent ID</label>
+                            <input type="number" name="parent_id" class="form-control" value="{{ $account->parent_id }}">
+                        </div>
+                        <button type="submit" class="btn btn-primary">Update</button>
+                        <a href="{{ route('admin.user-accounts.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        $(document).ready(function() {
+            function validateForm() {
+                let isValid = true;
+                $('#accountForm .error-message').remove();
+                $('#accountForm input[required], #accountForm select[required]').each(function() {
+                    if (!$(this).val()) {
+                        isValid = false;
+                        $(this).addClass('is-invalid');
+                        $(this).after('<span class="text-danger error-message">This field is required</span>');
+                    } else {
+                        $(this).removeClass('is-invalid');
+                    }
+                });
+                return isValid;
+            }
+            $('#accountForm').on('submit', function(e) {
+                e.preventDefault();
+                if (!validateForm()) {
+                    toastr.error('Please fix the validation errors.');
+                    return false;
+                }
+                var formData = $(this).serialize();
+                $.ajax({
+                    url: $(this).attr('action'),
+                    type: 'POST',
+                    data: formData,
+                    beforeSend: function() {
+                        $('button[type="submit"]').prop('disabled', true).html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Updating...');
+                    },
+                    success: function(response) {
+                        if (response.status == 1) {
+                            toastr.success(response.message);
+                            setTimeout(function() {
+                                window.location.href = response.redirect || "{{ route('admin.user-accounts.index') }}";
+                            }, 1000);
+                        } else {
+                            toastr.error(response.message || 'An error occurred');
+                        }
+                    },
+                    error: function(xhr) {
+                        if (xhr.responseJSON && xhr.responseJSON.errors) {
+                            $.each(xhr.responseJSON.errors, function(key, value) {
+                                toastr.error(value[0]);
+                            });
+                        } else if (xhr.responseJSON && xhr.responseJSON.message) {
+                            toastr.error(xhr.responseJSON.message);
+                        } else {
+                            toastr.error('An error occurred. Please try again.');
+                        }
+                    },
+                    complete: function() {
+                        $('button[type="submit"]').prop('disabled', false).html('Update');
+                    }
+                });
+            });
+        });
+    </script>
+@endsection

--- a/resources/views/admin/user_accounts/index.blade.php
+++ b/resources/views/admin/user_accounts/index.blade.php
@@ -1,0 +1,54 @@
+@extends('admin.layouts.app')
+@section('title', 'User Accounts | Deal24hours')
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h4 class="card-title">User Accounts</h4>
+                    <a href="{{ route('admin.user-accounts.create') }}" class="btn btn-sm btn-primary">
+                        <i class="bi bi-plus-lg"></i> Add Account
+                    </a>
+                </div>
+                <div class="card-body table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>#</th>
+                                <th>Name</th>
+                                <th>Email</th>
+                                <th>Phone</th>
+                                <th>User Type</th>
+                                <th>Status</th>
+                                <th>Verified</th>
+                                <th>Created At</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($accounts as $index => $account)
+                                <tr>
+                                    <td>{{ $index + 1 }}</td>
+                                    <td>{{ $account->name }}</td>
+                                    <td>{{ $account->email }}</td>
+                                    <td>{{ $account->phone }}</td>
+                                    <td>{{ $account->user_type }}</td>
+                                    <td>{{ $account->status == '1' ? 'Active' : 'Inactive' }}</td>
+                                    <td>{{ $account->is_verified == '1' ? 'Verified' : 'Not Verified' }}</td>
+                                    <td>{{ $account->created_at ? $account->created_at->format('d-m-Y') : '' }}</td>
+                                    <td>
+                                        <a href="{{ route('admin.user-accounts.edit', $account->id) }}" class="btn btn-sm btn-soft-primary" title="Edit"><i class="bi bi-pencil-square"></i></a>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="9" class="text-center">No user accounts found.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\UserAccountController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\VendorController;
 use App\Http\Controllers\Admin\VendorExportController;
@@ -99,6 +100,14 @@ Route::middleware(['auth'])->group(function () {
         Route::post('store', [UserController::class, 'store'])->name('store');
         Route::get('edit/{id}', [UserController::class, 'edit'])->name('edit');
         Route::put('update/{id}', [UserController::class, 'update'])->name('update');
+    });
+
+    Route::prefix('admin/user-accounts')->name('admin.user-accounts.')->group(function () {
+        Route::get('list', [UserAccountController::class, 'index'])->name('index');
+        Route::get('create', [UserAccountController::class, 'create'])->name('create');
+        Route::post('store', [UserAccountController::class, 'store'])->name('store');
+        Route::get('edit/{id}', [UserAccountController::class, 'edit'])->name('edit');
+        Route::put('update/{id}', [UserAccountController::class, 'update'])->name('update');
     });
 
     Route::prefix('admin/categories')->name('admin.categories.')->group(function () {


### PR DESCRIPTION
## Summary
- add UserAccount model and migration with account fields
- build UserAccountController and routes with server-side validation
- add admin views for listing and AJAX create/edit forms with client validation

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6893952af6e0832788e66de3366c8583