### PR TITLE
Add module table and role permission management page

### DIFF
--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Module extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'status',
+    ];
+
+    public function rolePermissions(): HasMany
+    {
+        return $this->hasMany(RolePermission::class);
+    }
+}

--- a/app/Models/RolePermission.php
+++ b/app/Models/RolePermission.php
@@ -12,15 +12,20 @@ class RolePermission extends Model
 
     protected $fillable = [
         'role_id',
-        'module',
+        'module_id',
         'can_add',
         'can_edit',
         'can_view',
-        'can_export'
+        'can_delete'
     ];
 
     public function role(): BelongsTo
     {
         return $this->belongsTo(Role::class);
+    }
+
+    public function module(): BelongsTo
+    {
+        return $this->belongsTo(Module::class);
     }
 }

--- a/database/migrations/2025_09_01_000000_create_modules_table.php
+++ b/database/migrations/2025_09_01_000000_create_modules_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('modules', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->enum('status', ['1', '2'])->default('1');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('modules');
+    }
+};

--- a/database/migrations/2025_09_01_010000_update_role_permissions_table.php
+++ b/database/migrations/2025_09_01_010000_update_role_permissions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('role_permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('module_id')->after('role_id');
+            $table->boolean('can_delete')->default(false)->after('can_view');
+            $table->foreign('module_id')->references('id')->on('modules')->onDelete('cascade');
+        });
+
+        Schema::table('role_permissions', function (Blueprint $table) {
+            $table->dropColumn(['module', 'can_export']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('role_permissions', function (Blueprint $table) {
+            $table->string('module');
+            $table->boolean('can_export')->default(false);
+            $table->dropForeign(['module_id']);
+            $table->dropColumn(['module_id', 'can_delete']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use Database\Seeders\RoleSeeder;
+use Database\Seeders\ModuleSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -16,7 +17,10 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        $this->call(RoleSeeder::class);
+        $this->call([
+            ModuleSeeder::class,
+            RoleSeeder::class,
+        ]);
 
         User::factory()->create([
             'name' => 'Test User',

--- a/database/seeders/ModuleSeeder.php
+++ b/database/seeders/ModuleSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Module;
+
+class ModuleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $modules = [
+            'categories',
+            'sub_categories',
+            'products',
+            'vendors',
+            'buyers',
+            'users',
+            'roles'
+        ];
+
+        foreach ($modules as $name) {
+            Module::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/resources/views/admin/roles/_roles_table.blade.php
+++ b/resources/views/admin/roles/_roles_table.blade.php
@@ -6,6 +6,9 @@
             <td>{{ htmlspecialchars($role->name) }}</td>
             <td>{{ $role->parent ? htmlspecialchars($role->parent->name) : '-' }}</td>
             <td>
+                <a href="{{ route('admin.roles.permissions', $role->id) }}" class="btn btn-sm btn-soft-secondary me-1" title="Permissions">
+                    <i class="bi bi-lock"></i>
+                </a>
                 <a href="{{ route('admin.roles.edit', $role->id) }}" class="btn btn-sm btn-soft-primary" title="Edit">
                     <iconify-icon icon="solar:pen-2-broken" class="fs-18"></iconify-icon>
                 </a>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -2,7 +2,7 @@
 @section('title', 'Edit Role | Deal24hours')
 @section('content')
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">Edit Role</h4>
@@ -34,26 +34,26 @@
                                         <label class="form-check-label" for="select_all">Select All Permissions</label>
                                     </div>
 
-                                    @php($rolePerms = $role->permissions->keyBy('module'))
-                                    @php($actions = ['view' => 'Show', 'add' => 'Add', 'edit' => 'Edit', 'export' => 'Export'])
+                                    @php($rolePerms = $role->permissions->keyBy('module_id'))
+                                    @php($actions = ['view' => 'View', 'add' => 'Add', 'edit' => 'Edit', 'delete' => 'Delete'])
                                     @foreach ($modules as $module)
-                                        @php($perm = $rolePerms->get($module))
-                                        <div class="card mb-3 module-block" data-module="{{ $module }}">
-                                            <div class="card-header fw-semibold text-capitalize">{{ $module }}</div>
+                                        @php($perm = $rolePerms->get($module->id))
+                                        <div class="card mb-3 module-block" data-module="{{ $module->id }}">
+                                            <div class="card-header fw-semibold text-capitalize">{{ $module->name }}</div>
                                             <div class="card-body d-flex flex-wrap gap-3">
                                                 @foreach ($actions as $key => $label)
                                                     <div class="d-flex flex-column align-items-start border rounded p-3" style="min-width: 180px;">
-                                                        <label class="form-check-label mb-2" for="{{ $module }}_{{ $key }}">
-                                                            {{ $label }} {{ ucfirst($module) }}
+                                                        <label class="form-check-label mb-2" for="{{ $module->id }}_{{ $key }}">
+                                                            {{ $label }} {{ ucfirst($module->name) }}
                                                         </label>
                                                         <div class="form-check form-switch">
                                                             <input
                                                                 class="form-check-input perm-checkbox"
                                                                 type="checkbox"
-                                                                name="permissions[{{ $module }}][]"
+                                                                name="permissions[{{ $module->id }}][]"
                                                                 value="{{ $key }}"
-                                                                data-module="{{ $module }}"
-                                                                id="{{ $module }}_{{ $key }}" @if($perm && $perm->{'can_'.$key}) checked @endif>
+                                                                data-module="{{ $module->id }}"
+                                                                id="{{ $module->id }}_{{ $key }}" @if($perm && $perm->{'can_'.$key}) checked @endif>
                                                         </div>
                                                     </div>
                                                 @endforeach

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -2,7 +2,7 @@
 @section('title', 'Roles | Deal24hours')
 @section('content')
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center gap-1">
                     <h4 class="card-title flex-grow-1">All Roles</h4>

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,8 @@ Route::middleware(['auth'])->group(function () {
         Route::post('store', [RoleController::class, 'store'])->name('store');
         Route::get('edit/{id}', [RoleController::class, 'edit'])->name('edit');
         Route::put('update/{id}', [RoleController::class, 'update'])->name('update');
+        Route::get('permissions/{id}', [RoleController::class, 'permissions'])->name('permissions');
+        Route::post('permissions/{id}', [RoleController::class, 'updatePermissions'])->name('permissions.update');
     });
 
     Route::prefix('admin/users')->name('admin.users.')->group(function () {


### PR DESCRIPTION
## Summary
- introduce modules table and seeder
- refactor role permissions to reference modules and support delete action
- add role permission management page with AJAX validation

## Testing
- `APP_KEY=base64:yI249mN+F9y5WRagGls0bXdhxOB13HE6hOSgkb+MJsg= php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68946e58d6748327971679edf76b2462